### PR TITLE
Spring Boot 2.4 and Spring Cloud 2020.0.0 upgrade

### DIFF
--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devdocker.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devdocker.properties
@@ -5,7 +5,7 @@
 logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
-logging.level.org.springframework.cloud.config=DEBUG
+logging.level.org.springframework.cloud.config=TRACE
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devgke.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devgke.properties
@@ -5,7 +5,7 @@
 logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
-logging.level.org.springframework.cloud.config=DEBUG
+logging.level.org.springframework.cloud.config=TRACE
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
@@ -5,7 +5,7 @@ spring.cloud.config.server.git.uri=file://D:/home/study/java/dockerproject/micro
 logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
-logging.level.org.springframework.cloud.config=DEBUG
+logging.level.org.springframework.cloud.config=TRACE
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <springfox.version>3.0.0</springfox.version>
 
@@ -82,6 +82,11 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>

--- a/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
@@ -8,7 +8,8 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Eureka client
+# Disable Config and Eureka clients
+spring.cloud.config.enabled=false
 eureka.client.enabled=false
 
 # Application

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
@@ -80,6 +80,11 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>

--- a/microcoffeeoncloud-discovery/src/main/resources/application.properties
+++ b/microcoffeeoncloud-discovery/src/main/resources/application.properties
@@ -6,3 +6,7 @@ server.port=8455
 
 # Custom embedded container configuration (unique port numbers make it easier to run on host using spring-boot:run)
 server.http.port=8092
+
+# Disable Eureka client registration
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false

--- a/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
@@ -1,2 +1,5 @@
 # Logging
 logging.level.study.microcoffee=DEBUG
+
+# Disable Config client
+spring.cloud.config.enabled=false

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <angularjs.version>1.8.0</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
@@ -86,6 +86,11 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>

--- a/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
@@ -2,5 +2,6 @@
 logging.level.root=info
 logging.level.study.microcoffee=DEBUG
 
-# Disable Eureka client
+# Disable Config and Eureka clients
+spring.cloud.config.enabled=false
 eureka.client.enabled=false

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <hikaku-version>3.1.2</hikaku-version>
         <springfox.version>3.0.0</springfox.version>
@@ -83,6 +83,11 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -8,5 +8,6 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Eureka client
+# Disable Config and Eureka clients
+spring.cloud.config.enabled=false
 eureka.client.enabled=false

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <modelmapper.version>2.3.8</modelmapper.version>
         <resilience4j.version>1.6.1</resilience4j.version>
@@ -72,13 +72,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <!-- Override version 1.3.1 in spring-cloud dependencies -->
-            <dependency>
-                <groupId>io.github.resilience4j</groupId>
-                <artifactId>resilience4j-micrometer</artifactId>
-                <version>${resilience4j.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -91,6 +84,11 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
@@ -146,13 +144,11 @@
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-spring-boot2</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-all</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
 
         <!-- Micrometer -->

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -33,7 +33,6 @@
         <spring-cloud.version>2020.0.0-RC1</spring-cloud.version>
 
         <modelmapper.version>2.3.8</modelmapper.version>
-        <resilience4j.version>1.6.1</resilience4j.version>
         <springfox.version>3.0.0</springfox.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/DiscoveryRestTemplateConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/DiscoveryRestTemplateConfig.java
@@ -4,7 +4,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+
+import study.microcoffee.order.common.logging.HttpLoggingInterceptor;
 
 /**
  * Discovery-supported RestTemplate configuration.
@@ -16,6 +20,11 @@ public class DiscoveryRestTemplateConfig {
     @LoadBalanced
     @Bean
     public RestTemplate discoveryRestTemplate() {
-        return new RestTemplate();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+
+        RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        restTemplate.getInterceptors().add(new HttpLoggingInterceptor(false));
+
+        return restTemplate;
     }
 }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/DiscoveryRestTemplateConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/DiscoveryRestTemplateConfig.java
@@ -1,42 +1,21 @@
 package study.microcoffee.order;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.web.client.RestTemplateCustomizer;
-import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.netflix.client.http.HttpRequest;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Discovery-supported RestTemplate configuration.
  */
 @Configuration
-@ConditionalOnClass(HttpRequest.class)
-@ConditionalOnProperty(value = "ribbon.http.client.enabled", matchIfMissing = false)
+@ConditionalOnProperty(value = "eureka.client.enabled", matchIfMissing = true)
 public class DiscoveryRestTemplateConfig {
 
-    private final Logger logger = LoggerFactory.getLogger(DiscoveryRestTemplateConfig.class);
-
-    /**
-     * Customizes the RestTemplate to use Ribbon load balancer to resolve service endpoints on format
-     * <code>http://SERVICE_ID/path</code>. SERVICE_ID is identical to the Spring application name defined by
-     * ${spring.application.name}.
-     * <p>
-     * Based on <a href=
-     * "https://github.com/hotblac/spanners/blob/master/spanners-mvc/src/main/java/org/dontpanic/spanners/springmvc/config/RestClientConfig.java">
-     * this source on GitHub</a>.
-     */
+    @LoadBalanced
     @Bean
-    public RestTemplateCustomizer ribbonClientRestTemplateCustomizer(
-        final RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory) {
-        return restTemplate -> {
-            logger.debug("RestTemplateCustomizer => requestFactory={}", ribbonClientHttpRequestFactory);
-
-            restTemplate.setRequestFactory(ribbonClientHttpRequestFactory);
-        };
+    public RestTemplate discoveryRestTemplate() {
+        return new RestTemplate();
     }
 }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicCreditRatingConsumer.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicCreditRatingConsumer.java
@@ -27,7 +27,7 @@ public class BasicCreditRatingConsumer implements CreditRatingConsumer {
 
     private String creditRatingEndpointUrl;
 
-    public BasicCreditRatingConsumer(@Qualifier("creditRatingRestTemplate") RestTemplate restTemplate,
+    public BasicCreditRatingConsumer(@Qualifier("basicRestTemplate") RestTemplate restTemplate,
         @Value("${app.creditrating.url}") String endpointUrl) {
         this.restTemplate = restTemplate;
         this.creditRatingEndpointUrl = endpointUrl;

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicRestTemplateFactory.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicRestTemplateFactory.java
@@ -19,15 +19,15 @@ import study.microcoffee.order.consumer.common.http.HttpClientFactory;
  * Note! RestTemplate instances are supposed to be thread-safe.
  */
 @Component
-public class CreditRatingRestTemplateFactory {
+public class BasicRestTemplateFactory {
 
-    private final Logger logger = LoggerFactory.getLogger(CreditRatingRestTemplateFactory.class);
+    private final Logger logger = LoggerFactory.getLogger(BasicRestTemplateFactory.class);
 
     /**
      * Creates a RestTemplate instance that uses a {@link BufferingClientHttpRequestFactory}.
      */
     @Bean
-    public RestTemplate creditRatingRestTemplate(@Value("${app.creditrating.timeout}") int timeout) {
+    public RestTemplate basicRestTemplate(@Value("${app.creditrating.timeout}") int timeout) {
         logger.info("app.creditrating.timeout={}", timeout);
 
         HttpClient httpClient = HttpClientFactory.createDefaultClient(timeout);

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumer.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumer.java
@@ -33,7 +33,6 @@ public class Resilience4JCreditRatingConsumer implements CreditRatingConsumer {
         this.restTemplate = restTemplate;
         this.creditRatingEndpointUrl = endpointUrl;
 
-        logger.debug("restTemplate={}", restTemplate);
         logger.debug("restTemplate.requestFactory={}", restTemplate.getRequestFactory());
         logger.debug("app.creditrating.url={}", endpointUrl);
     }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumer.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumer.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -29,10 +28,12 @@ public class Resilience4JCreditRatingConsumer implements CreditRatingConsumer {
 
     private String creditRatingEndpointUrl;
 
-    public Resilience4JCreditRatingConsumer(RestTemplateBuilder builder, @Value("${app.creditrating.url}") String endpointUrl) {
-        restTemplate = builder.rootUri(endpointUrl).build();
+    public Resilience4JCreditRatingConsumer(@Qualifier("discoveryRestTemplate") RestTemplate restTemplate,
+        @Value("${app.creditrating.url}") String endpointUrl) {
+        this.restTemplate = restTemplate;
         this.creditRatingEndpointUrl = endpointUrl;
 
+        logger.debug("restTemplate={}", restTemplate);
         logger.debug("restTemplate.requestFactory={}", restTemplate.getRequestFactory());
         logger.debug("app.creditrating.url={}", endpointUrl);
     }

--- a/microcoffeeoncloud-order/src/main/resources/application.properties
+++ b/microcoffeeoncloud-order/src/main/resources/application.properties
@@ -10,6 +10,3 @@ server.http.port=8082
 # Actuator
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.metrics.tags.application=${spring.application.name}
-
-# Use BlockingLoadBalancerClient instead of Spring Cloud Ribbon (in maintenance mode)
-spring.cloud.loadbalancer.ribbon.enabled=false

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/ApplicationTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/ApplicationTest.java
@@ -2,13 +2,17 @@ package study.microcoffee.order;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+
+import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
 
 /**
  * Test of loading of application context.
  */
 @SpringBootTest
 @TestPropertySource("/application-test.properties")
+@Import(DiscoveryRestTemplateTestConfig.class)
 public class ApplicationTest {
 
     @Test

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.HttpStatus;
@@ -20,11 +21,14 @@ import org.springframework.test.context.TestPropertySource;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
+
 /**
  * Integration tests of {@link MenuController}.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("/application-test.properties")
+@Import(DiscoveryRestTemplateTestConfig.class)
 @ActiveProfiles("itest")
 @Profile("itest")
 public class MenuControllerIT {

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerIT.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,12 +35,15 @@ import io.github.resilience4j.retry.RetryRegistry;
 import study.microcoffee.order.api.order.model.OrderModel;
 import study.microcoffee.order.consumer.creditrating.CreditRating;
 import study.microcoffee.order.domain.DrinkType;
+import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
 
 /**
  * Integration tests of {@link OrderController}.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMetrics
 @TestPropertySource("/application-test.properties")
+@Import(DiscoveryRestTemplateTestConfig.class)
 @ActiveProfiles("itest")
 @Profile("itest")
 public class OrderControllerIT {

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
@@ -74,10 +74,6 @@ public class Resilience4JCreditRatingConsumerTest {
         });
     }
 
-    private String buildServicePath(String customerId) throws UnsupportedEncodingException {
-        return "/api/coffeeshop/creditrating/" + UriUtils.encodePathSegment(customerId, StandardCharsets.UTF_8.name());
-    }
-
     private String buildServiceUrl(String customerId) throws UnsupportedEncodingException {
         UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
             .path("/api/coffeeshop/creditrating") //

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
@@ -11,13 +11,14 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,25 +28,31 @@ import study.microcoffee.order.exception.ServiceCallFailedException;
 /**
  * Unit tests of {@link Resilience4JCreditRatingConsumer}.
  */
-@RestClientTest(Resilience4JCreditRatingConsumer.class)
-@TestPropertySource("/application-test.properties")
 public class Resilience4JCreditRatingConsumerTest {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private static final String CREDITRATING_SERVICE_URL = "http://dummy";
 
-    @Autowired
     private MockRestServiceServer server;
 
-    @Autowired
+    private RestTemplate restTemplate = new RestTemplate();
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     private CreditRatingConsumer creditRatingConsumer;
+
+    @BeforeEach
+    public void setUp() {
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+
+        creditRatingConsumer = new Resilience4JCreditRatingConsumer(restTemplate, CREDITRATING_SERVICE_URL);
+    }
 
     @Test
     public void getCreateRatingWhenHttpStatus200ShouldReturnRating() throws Exception {
         final String customerId = "john@company.com";
         final String expectedContent = objectMapper.writeValueAsString(new CreditRating(50));
 
-        server.expect(once(), requestTo(buildServicePath(customerId))) //
+        server.expect(once(), requestTo(buildServiceUrl(customerId))) //
             .andExpect(method(HttpMethod.GET)) //
             .andRespond(withSuccess(expectedContent, MediaType.APPLICATION_JSON));
 
@@ -59,7 +66,7 @@ public class Resilience4JCreditRatingConsumerTest {
         Assertions.assertThrows(ServiceCallFailedException.class, () -> {
             final String customerId = "john@company.com";
 
-            server.expect(once(), requestTo(buildServicePath(customerId))) //
+            server.expect(once(), requestTo(buildServiceUrl(customerId))) //
                 .andExpect(method(HttpMethod.GET)) //
                 .andRespond(withServerError());
 
@@ -69,5 +76,13 @@ public class Resilience4JCreditRatingConsumerTest {
 
     private String buildServicePath(String customerId) throws UnsupportedEncodingException {
         return "/api/coffeeshop/creditrating/" + UriUtils.encodePathSegment(customerId, StandardCharsets.UTF_8.name());
+    }
+
+    private String buildServiceUrl(String customerId) throws UnsupportedEncodingException {
+        UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
+            .path("/api/coffeeshop/creditrating") //
+            .pathSegment(UriUtils.encodePathSegment(customerId, StandardCharsets.UTF_8.name())) //
+            .build();
+        return serviceUrl.toUriString();
     }
 }

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoMenuRepositoryIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoMenuRepositoryIT.java
@@ -8,11 +8,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.TestPropertySource;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+
+import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
 
 /**
  * Integration tests of {@link MongoMenuRepository}.
@@ -21,6 +24,7 @@ import com.mongodb.client.MongoDatabase;
  */
 @SpringBootTest
 @TestPropertySource("/application-test.properties")
+@Import(DiscoveryRestTemplateTestConfig.class)
 public class EmbeddedMongoMenuRepositoryIT {
 
     @Autowired

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoOrderRepositoryIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoOrderRepositoryIT.java
@@ -7,10 +7,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.repository.Repository;
 
 import study.microcoffee.order.domain.DrinkType;
 import study.microcoffee.order.domain.Order;
+import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
 
 /**
  * Integration tests of {@link OrderRepository} that uses an auto-configured Embedded MongoDB database.
@@ -18,6 +20,7 @@ import study.microcoffee.order.domain.Order;
  * The @DataMongoTest annotation will scan for @Document classes and Spring {@link Repository} classes.
  */
 @DataMongoTest
+@Import(DiscoveryRestTemplateTestConfig.class)
 public class EmbeddedMongoOrderRepositoryIT {
 
     @Autowired

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/test/DiscoveryRestTemplateTestConfig.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/test/DiscoveryRestTemplateTestConfig.java
@@ -1,0 +1,17 @@
+package study.microcoffee.order.test;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Test configuration class for Discovery RestTemplate.
+ */
+@TestConfiguration
+public class DiscoveryRestTemplateTestConfig {
+
+    @Bean
+    public RestTemplate discoveryRestTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -11,7 +11,8 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Eureka client
+# Disable Config and Eureka clients
+spring.cloud.config.enabled=false
 eureka.client.enabled=false
 
 # Downstream REST services
@@ -23,3 +24,4 @@ app.creditrating.timeout=-1
 resilience4j.retry.instances.creditRating.maxRetryAttempts=2
 resilience4j.retry.instances.creditRating.waitDuration=1s
 resilience4j.retry.instances.creditRating.retryExceptions[0]=study.microcoffee.order.exception.ServiceCallFailedException
+


### PR DESCRIPTION
- Upgraded Spring Boot 2.3.6.RELEASE -> 2.4.1 and Spring Cloud Hoxton.SR9 -> 2020.0.0-RC1.
- Added spring-cloud-starter-bootstrap because bootstrap properties are not enabled by default any longer.
- Replaced Ribbon-aware RestTemplate by @LoadBalanced annotated RestTemplate and activated by eureka.client.enabled=true (or absent property).
- Importing new DiscoveryRestTemplateTestConfig in all Order tests using Spring application context to be used instead of @LoadBalanced RestTemplate.
- Disabled Config client by spring.cloud.config.enabled=false in unit tests.
- Added properties to disable Eureka client registration.

