### PR TITLE
Migrate bootstrap to spring config import

### DIFF
--- a/microcoffeeoncloud-configserver/run-local.bat
+++ b/microcoffeeoncloud-configserver/run-local.bat
@@ -2,6 +2,8 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devdocker.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devdocker.properties
@@ -6,6 +6,7 @@ logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
 logging.level.org.springframework.cloud.config=TRACE
+logging.level.web=INFO
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devgke.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devgke.properties
@@ -6,6 +6,7 @@ logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
 logging.level.org.springframework.cloud.config=TRACE
+logging.level.web=INFO
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
@@ -6,6 +6,7 @@ logging.level.root=INFO
 logging.level.study.microcoffee=DEBUG
 logging.level.study.microcoffee.configserver.health=INFO
 logging.level.org.springframework.cloud.config=TRACE
+logging.level.web=INFO
 
 # SSL
 server.ssl.enabled=true

--- a/microcoffeeoncloud-configserver/src/main/resources/application.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=configserver
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -84,11 +84,6 @@
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 

--- a/microcoffeeoncloud-creditrating/run-local.bat
+++ b/microcoffeeoncloud-creditrating/run-local.bat
@@ -2,6 +2,9 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-creditrating/src/main/resources/application.properties
+++ b/microcoffeeoncloud-creditrating/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=creditrating
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 
@@ -6,3 +8,8 @@ server.port=8446
 
 # Custom embedded container configuration (unique port numbers make it easier to run on host using spring-boot:run)
 server.http.port=8083
+
+# Spring Cloud Config server
+#spring.config.import=configserver:
+spring.config.import=optional:configserver:
+spring.cloud.config.profile=${spring.profiles.active}

--- a/microcoffeeoncloud-creditrating/src/main/resources/application.properties
+++ b/microcoffeeoncloud-creditrating/src/main/resources/application.properties
@@ -13,3 +13,4 @@ server.http.port=8083
 #spring.config.import=configserver:
 spring.config.import=optional:configserver:
 spring.cloud.config.profile=${spring.profiles.active}
+spring.cloud.config.fail-fast=true

--- a/microcoffeeoncloud-creditrating/src/main/resources/bootstrap-devlocal.properties
+++ b/microcoffeeoncloud-creditrating/src/main/resources/bootstrap-devlocal.properties
@@ -1,2 +1,0 @@
-# The Config Server URL is defined by an environment variable in other profiles
-spring.cloud.config.uri=https://localhost:8454

--- a/microcoffeeoncloud-creditrating/src/main/resources/bootstrap.properties
+++ b/microcoffeeoncloud-creditrating/src/main/resources/bootstrap.properties
@@ -1,1 +1,0 @@
-spring.application.name=creditrating

--- a/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
@@ -8,10 +8,13 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Config and Eureka clients
+# Disable Config client
 # WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
 # java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
 spring.cloud.config.enabled=true
+spring.cloud.config.fail-fast=false
+
+# Disable Eureka client
 eureka.client.enabled=false
 
 # Application

--- a/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-creditrating/src/test/resources/application-test.properties
@@ -9,7 +9,9 @@ server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
 # Disable Config and Eureka clients
-spring.cloud.config.enabled=false
+# WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
+# java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
+spring.cloud.config.enabled=true
 eureka.client.enabled=false
 
 # Application

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -82,11 +82,6 @@
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 

--- a/microcoffeeoncloud-discovery/run-local.bat
+++ b/microcoffeeoncloud-discovery/run-local.bat
@@ -2,6 +2,9 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-discovery/src/main/resources/application.properties
+++ b/microcoffeeoncloud-discovery/src/main/resources/application.properties
@@ -17,3 +17,4 @@ eureka.client.fetch-registry=false
 #spring.config.import=configserver:
 spring.config.import=optional:configserver:
 spring.cloud.config.profile=${spring.profiles.active}
+spring.cloud.config.fail-fast=true

--- a/microcoffeeoncloud-discovery/src/main/resources/application.properties
+++ b/microcoffeeoncloud-discovery/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=discovery
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 
@@ -10,3 +12,8 @@ server.http.port=8092
 # Disable Eureka client registration
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+
+# Spring Cloud Config server
+#spring.config.import=configserver:
+spring.config.import=optional:configserver:
+spring.cloud.config.profile=${spring.profiles.active}

--- a/microcoffeeoncloud-discovery/src/main/resources/bootstrap-devlocal.properties
+++ b/microcoffeeoncloud-discovery/src/main/resources/bootstrap-devlocal.properties
@@ -1,2 +1,0 @@
-# The Config Server URL is defined by an environment variable in other profiles
-spring.cloud.config.uri=https://localhost:8454

--- a/microcoffeeoncloud-discovery/src/main/resources/bootstrap.properties
+++ b/microcoffeeoncloud-discovery/src/main/resources/bootstrap.properties
@@ -1,1 +1,0 @@
-spring.application.name=discovery

--- a/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
@@ -2,4 +2,6 @@
 logging.level.study.microcoffee=DEBUG
 
 # Disable Config client
-spring.cloud.config.enabled=false
+# WORKAROUND: Reenabled to avoid issue when migrating from bootstrap to spring.config.import=configserver:
+# java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
+spring.cloud.config.enabled=true

--- a/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-discovery/src/test/resources/application-test.properties
@@ -5,3 +5,4 @@ logging.level.study.microcoffee=DEBUG
 # WORKAROUND: Reenabled to avoid issue when migrating from bootstrap to spring.config.import=configserver:
 # java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
 spring.cloud.config.enabled=true
+spring.cloud.config.fail-fast=false

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -88,11 +88,6 @@
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 

--- a/microcoffeeoncloud-gateway/run-local.bat
+++ b/microcoffeeoncloud-gateway/run-local.bat
@@ -2,6 +2,9 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-gateway/src/main/resources/application.properties
+++ b/microcoffeeoncloud-gateway/src/main/resources/application.properties
@@ -13,3 +13,4 @@ server.servlet.context-path=/
 #spring.config.import=configserver:
 spring.config.import=optional:configserver:
 spring.cloud.config.profile=${spring.profiles.active}
+spring.cloud.config.fail-fast=true

--- a/microcoffeeoncloud-gateway/src/main/resources/application.properties
+++ b/microcoffeeoncloud-gateway/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=gateway
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 
@@ -6,3 +8,8 @@ server.port=8443
 
 # Define context root.
 server.servlet.context-path=/
+
+# Spring Cloud Config server
+#spring.config.import=configserver:
+spring.config.import=optional:configserver:
+spring.cloud.config.profile=${spring.profiles.active}

--- a/microcoffeeoncloud-gateway/src/main/resources/bootstrap-devlocal.properties
+++ b/microcoffeeoncloud-gateway/src/main/resources/bootstrap-devlocal.properties
@@ -1,2 +1,0 @@
-# The Config Server URL is defined by an environment variable in other profiles
-spring.cloud.config.uri=https://localhost:8454

--- a/microcoffeeoncloud-gateway/src/main/resources/bootstrap.properties
+++ b/microcoffeeoncloud-gateway/src/main/resources/bootstrap.properties
@@ -1,1 +1,0 @@
-spring.application.name=gateway

--- a/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
@@ -2,8 +2,11 @@
 logging.level.root=info
 logging.level.study.microcoffee=DEBUG
 
-# Disable Config and Eureka clients
+# Disable Config client
 # WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
 # java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
 spring.cloud.config.enabled=true
+spring.cloud.config.fail-fast=false
+
+# Disable Eureka client
 eureka.client.enabled=false

--- a/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-gateway/src/test/resources/application-test.properties
@@ -3,5 +3,7 @@ logging.level.root=info
 logging.level.study.microcoffee=DEBUG
 
 # Disable Config and Eureka clients
-spring.cloud.config.enabled=false
+# WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
+# java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
+spring.cloud.config.enabled=true
 eureka.client.enabled=false

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -85,11 +85,6 @@
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 

--- a/microcoffeeoncloud-location/run-local.bat
+++ b/microcoffeeoncloud-location/run-local.bat
@@ -2,6 +2,9 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-location/src/main/resources/application.properties
+++ b/microcoffeeoncloud-location/src/main/resources/application.properties
@@ -13,3 +13,4 @@ server.http.port=8081
 #spring.config.import=configserver:
 spring.config.import=optional:configserver:
 spring.cloud.config.profile=${spring.profiles.active}
+spring.cloud.config.fail-fast=true

--- a/microcoffeeoncloud-location/src/main/resources/application.properties
+++ b/microcoffeeoncloud-location/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=location
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 
@@ -6,3 +8,8 @@ server.port=8444
 
 # Custom embedded container configuration (unique port numbers make it easier to run on host using spring-boot:run)
 server.http.port=8081
+
+# Spring Cloud Config server
+#spring.config.import=configserver:
+spring.config.import=optional:configserver:
+spring.cloud.config.profile=${spring.profiles.active}

--- a/microcoffeeoncloud-location/src/main/resources/bootstrap-devlocal.properties
+++ b/microcoffeeoncloud-location/src/main/resources/bootstrap-devlocal.properties
@@ -1,2 +1,0 @@
-# The Config Server URL is defined by an environment variable in other profiles
-spring.cloud.config.uri=https://localhost:8454

--- a/microcoffeeoncloud-location/src/main/resources/bootstrap.properties
+++ b/microcoffeeoncloud-location/src/main/resources/bootstrap.properties
@@ -1,1 +1,0 @@
-spring.application.name=location

--- a/microcoffeeoncloud-location/src/test/java/study/microcoffee/location/api/LocationSpecificationTest.java
+++ b/microcoffeeoncloud-location/src/test/java/study/microcoffee/location/api/LocationSpecificationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
 
 import de.codecentric.hikaku.Hikaku;
 import de.codecentric.hikaku.HikakuConfig;
@@ -29,6 +30,7 @@ import kotlin.jvm.functions.Function1;
  * @see <a href="https://github.com/codecentric/hikaku">https://github.com/codecentric/hikaku</a>
  */
 @SpringBootTest
+@TestPropertySource("/application-test.properties")
 public class LocationSpecificationTest {
 
     private static final String API_SPEC_FILE = "static/swagger/location-apispec-3.0.yml";

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -9,5 +9,7 @@ server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
 # Disable Config and Eureka clients
-spring.cloud.config.enabled=false
+# WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
+# java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
+spring.cloud.config.enabled=true
 eureka.client.enabled=false

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -8,8 +8,11 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Config and Eureka clients
+# Disable Config client
 # WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
 # java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
 spring.cloud.config.enabled=true
+spring.cloud.config.fail-fast=false
+
+# Disable Eureka client
 eureka.client.enabled=false

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -85,11 +85,6 @@
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 

--- a/microcoffeeoncloud-order/run-local.bat
+++ b/microcoffeeoncloud-order/run-local.bat
@@ -2,6 +2,9 @@
 
 setlocal
 
-mvn spring-boot:run -Dspring-boot.run.profiles=devlocal
+set SPRING_PROFILES_ACTIVE=devlocal
+set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
+
+mvn spring-boot:run
 
 endlocal

--- a/microcoffeeoncloud-order/src/main/resources/application.properties
+++ b/microcoffeeoncloud-order/src/main/resources/application.properties
@@ -17,3 +17,4 @@ management.metrics.tags.application=${spring.application.name}
 #spring.config.import=configserver:
 spring.config.import=optional:configserver:
 spring.cloud.config.profile=${spring.profiles.active}
+spring.cloud.config.fail-fast=true

--- a/microcoffeeoncloud-order/src/main/resources/application.properties
+++ b/microcoffeeoncloud-order/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=order
+
 # Support shutdown. (Creates /shutdown endpoint)
 endpoints.shutdown.enabled=true
 
@@ -10,3 +12,8 @@ server.http.port=8082
 # Actuator
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.metrics.tags.application=${spring.application.name}
+
+# Spring Cloud Config server
+#spring.config.import=configserver:
+spring.config.import=optional:configserver:
+spring.cloud.config.profile=${spring.profiles.active}

--- a/microcoffeeoncloud-order/src/main/resources/bootstrap-devlocal.properties
+++ b/microcoffeeoncloud-order/src/main/resources/bootstrap-devlocal.properties
@@ -1,2 +1,0 @@
-# The Config Server URL is defined by an environment variable in other profiles
-spring.cloud.config.uri=https://localhost:8454

--- a/microcoffeeoncloud-order/src/main/resources/bootstrap.properties
+++ b/microcoffeeoncloud-order/src/main/resources/bootstrap.properties
@@ -1,1 +1,0 @@
-spring.application.name=order

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
@@ -22,7 +22,7 @@ import study.microcoffee.order.repository.MenuRepository;
  * Unit tests of {@link MenuController}.
  */
 @WebMvcTest(MenuController.class)
-@TestPropertySource(properties = { "logging.level.study.microcoffee=DEBUG" })
+@TestPropertySource("/application-test.properties")
 @Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class })
 public class MenuControllerTest {
 

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -40,7 +40,7 @@ import study.microcoffee.order.repository.OrderRepository;
  * Unit tests of {@link OrderController}.
  */
 @WebMvcTest(OrderController.class)
-@TestPropertySource(properties = { "logging.level.study.microcoffee=DEBUG" })
+@TestPropertySource("/application-test.properties")
 @Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class })
 public class OrderControllerTest {
 

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoOrderRepositoryIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/repository/EmbeddedMongoOrderRepositoryIT.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.repository.Repository;
+import org.springframework.test.context.TestPropertySource;
 
 import study.microcoffee.order.domain.DrinkType;
 import study.microcoffee.order.domain.Order;
@@ -20,6 +21,7 @@ import study.microcoffee.order.test.DiscoveryRestTemplateTestConfig;
  * The @DataMongoTest annotation will scan for @Document classes and Spring {@link Repository} classes.
  */
 @DataMongoTest
+@TestPropertySource("/application-test.properties")
 @Import(DiscoveryRestTemplateTestConfig.class)
 public class EmbeddedMongoOrderRepositoryIT {
 

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -11,15 +11,17 @@ server.ssl.key-store=classpath:microcoffee-keystore.jks
 server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
-# Disable Config and Eureka clients
+# Disable Config client
 # WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
 # java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
 spring.cloud.config.enabled=true
+spring.cloud.config.fail-fast=false
+
+# Disable Eureka client
 eureka.client.enabled=false
 
 # Downstream REST services
 app.creditrating.url=http://localhost:8083
-#app.creditrating.url=https://localhost:8446
 app.creditrating.timeout=-1
 
 # Resilience4J Retry

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -12,7 +12,9 @@ server.ssl.key-password=12345678
 server.ssl.key-alias=localhost
 
 # Disable Config and Eureka clients
-spring.cloud.config.enabled=false
+# WORKAROUND: Reenabled Config client to avoid issue when migrating from bootstrap to spring.config.import=configserver:
+# java.lang.IllegalStateException: File extension is not known to any PropertySourceLoader. If the location is meant to reference a directory, it must end in '/'
+spring.cloud.config.enabled=true
 eureka.client.enabled=false
 
 # Downstream REST services


### PR DESCRIPTION
- Migrated from bootstrap to spring.config.import=configserver:. Removed spring-cloud-starter-bootstrap artifact and bootstrap property files.
- Updated run-local.bat to set SPRING_PROFILES_ACTIVE and SPRING_CLOUD_CONFIG_URI as environment variables. Removed -Dspring-boot.run.profiles flag.
- Fix on Config client issue trying to read properties of default profile, not activated profile: spring.cloud.config.profile=${spring.profiles.active}
- Workaround on Config client IllegalStateException exception when disabling Config client by spring.cloud.config.enabled=false for unit tests: Must set flag to true and use spring.config.import=optional:configserver: instead.
- Added spring.cloud.config.fail-fast=true (false in test code). Updated some tests to use application-test.properties.
- Added logging.level.web=INFO.