### PR TITLE
GitHub actions fix deprecated credentials param

### DIFF
--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Display current gcloud environment
         run: |-
-         gcloud info
+          gcloud info
 
       - name: Create cluster
         run: |-

--- a/.github/workflows/delete-cluster-gke.yml
+++ b/.github/workflows/delete-cluster-gke.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@master
         with:
-          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
           project_id: ${{ env.GKE_PROJECT }}
+          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Display current gcloud environment
         run: |-
-         gcloud info
+          gcloud info
 
       - name: Delete firewall rules
         run: |-

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -32,7 +32,13 @@ jobs:
 
       - name: Display current gcloud environment
         run: |-
-         gcloud info
+          gcloud info
+
+      # https://github.com/marketplace/actions/authenticate-to-google-cloud
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@main
+        with:
+          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
@@ -40,7 +46,7 @@ jobs:
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SRVGHA_KEY }}
+          #credentials: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Deploy and wait for Keycloak authorization server to start
         run: |-

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -29,16 +29,11 @@ jobs:
         with:
           project_id: ${{ env.GKE_PROJECT }}
           service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
+          export_default_credentials: true
 
       - name: Display current gcloud environment
         run: |-
           gcloud info
-
-      # https://github.com/marketplace/actions/authenticate-to-google-cloud
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@main
-        with:
-          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
@@ -46,7 +41,6 @@ jobs:
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}
-          #credentials: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Deploy and wait for Keycloak authorization server to start
         run: |-

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Display current gcloud environment
         run: |-
-         gcloud info
+          gcloud info
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}
-          #credentials: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Undeploy all and wait for pods to terminate
         run: |-

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}
-          credentials: ${{ secrets.GKE_SRVGHA_KEY }}
+          #credentials: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Undeploy all and wait for pods to terminate
         run: |-

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           project_id: ${{ env.GKE_PROJECT }}
           service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
+          export_default_credentials: true
 
       - name: Display current gcloud environment
         run: |-


### PR DESCRIPTION
- Use export_default_credentials = true in google-github-actions/setup-gcloud instead of google-github-actions/get-gke-credentials with credentials parameter or google-github-actions/auth action.