### PR TITLE
Spring boot 261 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Date | Change
 19.05.2021 | Integrated Keycloak, an authorization server, in Microcoffee. CreditRating API is now requiring the OAuth2 client credentials grant.
 30.05.2021 | Upgraded to Spring Boot 2.5.0 and Spring Cloud 2020.0.3.
 23.11.2021 | Added extra on required setup for GitHub Actions workflows.
+09.12.2021 | Upgraded to Spring Boot 2.6.1 and Spring Cloud 2021.0.0.
 
 ## Contents
 
@@ -145,7 +146,7 @@ by `microcoffeeoncloud-certificates`. Also a suite of types to use when mocking 
 provided.
 
 ## <a name="prerequisite"></a>Prerequisite
-Microcoffee is developed on Windows 10 and tested on Docker 19.03.1/Docker Compose 1.24.1 running on Oracle VM VirtualBox 6.1.18.
+Microcoffee is developed on Windows 10 and tested on Docker 19.03.1/Docker Compose 1.24.1 running on Oracle VM VirtualBox 6.1.28.
 
 The code was originally written in Java 8, but is later migrated to Java 11. Only three issues were found during the migration:
 * ClassNotFoundException for javax.xml.bind.JAXBContext. Fixed by adding dependency to org.glassfish.jaxb:jaxb-runtime.
@@ -1704,7 +1705,6 @@ Some useful resources:
 - (Google Kubernetes Engine API permissions)[https://cloud.google.com/kubernetes-engine/docs/reference/api-permissions]
 - (Compute Engine IAM roles and permissions)[https://cloud.google.com/compute/docs/access/iam]
 
-
 #### Setup for running the workflows
 
 ##### Create an access token in DockerHub
@@ -1810,3 +1810,11 @@ And another one for the password.
 - Name: KEYCLOAK_PASSWORD
 - Value: admin
 - Add secret
+
+#### Tips & tricks
+
+##### Fetch credentials for a running cluster
+
+If you need to connect to a running cluster from your local development machine, run the following command.
+
+    gcloud container clusters get-credentials microcoffeeoncloud-cluster

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-configserver/docker-compose.yml
+++ b/microcoffeeoncloud-configserver/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         environment:
             - SPRING_PROFILES_ACTIVE=devdocker
             - SPRING_CLOUD_CONFIG_SERVER_GIT_URI=https://github.com/dagbjorn/microcoffeeoncloud-appconfig.git
+            - SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL=master
         domainname: microcoffee.study
         networks:
             configserver:

--- a/microcoffeeoncloud-configserver/k8s-service-aks.yml
+++ b/microcoffeeoncloud-configserver/k8s-service-aks.yml
@@ -39,6 +39,8 @@ spec:
           value: "devgke"
         - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
           value: "https://github.com/dagbjorn/microcoffeeoncloud-appconfig.git"
+        - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL
+          value: "master"
 ---
 apiVersion: v1
 kind: Service

--- a/microcoffeeoncloud-configserver/k8s-service-eks.yml
+++ b/microcoffeeoncloud-configserver/k8s-service-eks.yml
@@ -39,6 +39,8 @@ spec:
           value: "devgke"
         - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
           value: "https://github.com/dagbjorn/microcoffeeoncloud-appconfig.git"
+        - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL
+          value: "master"
 ---
 apiVersion: v1
 kind: Service

--- a/microcoffeeoncloud-configserver/k8s-service-gke.yml
+++ b/microcoffeeoncloud-configserver/k8s-service-gke.yml
@@ -39,6 +39,8 @@ spec:
           value: "devgke"
         - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
           value: "https://github.com/dagbjorn/microcoffeeoncloud-appconfig.git"
+        - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL
+          value: "master"
 ---
 apiVersion: v1
 kind: Service

--- a/microcoffeeoncloud-configserver/k8s-service-mkube.yml
+++ b/microcoffeeoncloud-configserver/k8s-service-mkube.yml
@@ -39,6 +39,8 @@ spec:
           value: "devgke"
         - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
           value: "https://github.com/dagbjorn/microcoffeeoncloud-appconfig.git"
+        - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL
+          value: "master"
 ---
 apiVersion: v1
 kind: Service

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
+++ b/microcoffeeoncloud-configserver/src/main/resources/application-devlocal.properties
@@ -1,5 +1,6 @@
 # GIT backend
 spring.cloud.config.server.git.uri=file://D:/home/study/java/dockerproject/microcoffeeoncloud-appconfig
+spring.cloud.config.server.git.default-label=master
 
 # Logging
 logging.level.root=INFO

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
         <springfox.version>3.0.0</springfox.version>
 

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/Springfox3SpringBoot26Config.java
@@ -1,0 +1,69 @@
+package study.microcoffee.creditrating;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
+
+/**
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy.
+ * <p>
+ * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
+ * in <code>application.properties</code> as follows.
+ *
+ * <pre>
+ * spring.mvc.pathmatch.matching-strategy=ant-path-matcher
+ * </pre>
+ *
+ * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
+ * from Springfox to Springdoc.
+ *
+ * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
+ * @see <a href=
+ *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
+ *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>
+ */
+@Configuration
+public class Springfox3SpringBoot26Config {
+
+    @Bean
+    public BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+        return new BeanPostProcessor() {
+
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof WebMvcRequestHandlerProvider || bean instanceof WebFluxRequestHandlerProvider) {
+                    customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+                }
+                return bean;
+            }
+
+            private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings) {
+                List<T> copy = mappings.stream().filter(mapping -> mapping.getPatternParser() == null).collect(Collectors.toList());
+                mappings.clear();
+                mappings.addAll(copy);
+            }
+
+            @SuppressWarnings("unchecked")
+            private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+                try {
+                    Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+                    field.setAccessible(true); // NOSONAR Allow in workaround
+                    return (List<RequestMappingInfoHandlerMapping>) field.get(bean);
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+    }
+}

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/Springfox3SpringBoot26Config.java
@@ -15,8 +15,9 @@ import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
 import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
 
 /**
- * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
- * spring.mvc.pathmatch.matching-strategy.
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out Actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy. The code is copied from
+ * <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>.
  * <p>
  * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
  * in <code>application.properties</code> as follows.
@@ -28,7 +29,6 @@ import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
  * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
  * from Springfox to Springdoc.
  *
- * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
  * @see <a href=
  *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
  *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>

--- a/microcoffeeoncloud-creditrating/src/main/resources/application.properties
+++ b/microcoffeeoncloud-creditrating/src/main/resources/application.properties
@@ -15,3 +15,6 @@ spring.config.import=optional:configserver:
 spring.cloud.config.fail-fast=true
 # Workaround in Spring Cloud 2020.0.0 (fixed in 2020.0.1)
 #spring.cloud.config.profile=${spring.profiles.active}
+
+# Workaround for SpringFox 3 and Spring Boot 2.6. Also see Springfox3SpringBoot26Config.
+spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5.0
+FROM mongo:5.0.4
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -15,7 +15,7 @@
         <mongo-java-driver.version>3.12.10</mongo-java-driver.version>
 
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <gmavenplus-plugin.version>1.13.0</gmavenplus-plugin.version>
+        <gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
         <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,11 +30,11 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
-        <bootstrap.version>5.1.0</bootstrap.version>
+        <bootstrap.version>5.1.3</bootstrap.version>
         <springfox.version>3.0.0</springfox.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,7 +30,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
         <!-- 3.2.0 and higher gives unexpected test result
             Expected, but unable to find:

--- a/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/Springfox3SpringBoot26Config.java
@@ -15,8 +15,9 @@ import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
 import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
 
 /**
- * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
- * spring.mvc.pathmatch.matching-strategy.
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out Actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy. The code is copied from
+ * <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>.
  * <p>
  * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
  * in <code>application.properties</code> as follows.
@@ -28,7 +29,6 @@ import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
  * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
  * from Springfox to Springdoc.
  *
- * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
  * @see <a href=
  *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
  *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>

--- a/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/Springfox3SpringBoot26Config.java
@@ -1,0 +1,69 @@
+package study.microcoffee.location;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
+
+/**
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy.
+ * <p>
+ * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
+ * in <code>application.properties</code> as follows.
+ *
+ * <pre>
+ * spring.mvc.pathmatch.matching-strategy=ant-path-matcher
+ * </pre>
+ *
+ * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
+ * from Springfox to Springdoc.
+ *
+ * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
+ * @see <a href=
+ *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
+ *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>
+ */
+@Configuration
+public class Springfox3SpringBoot26Config {
+
+    @Bean
+    public BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+        return new BeanPostProcessor() {
+
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof WebMvcRequestHandlerProvider || bean instanceof WebFluxRequestHandlerProvider) {
+                    customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+                }
+                return bean;
+            }
+
+            private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings) {
+                List<T> copy = mappings.stream().filter(mapping -> mapping.getPatternParser() == null).collect(Collectors.toList());
+                mappings.clear();
+                mappings.addAll(copy);
+            }
+
+            @SuppressWarnings("unchecked")
+            private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+                try {
+                    Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+                    field.setAccessible(true); // NOSONAR Allow in workaround
+                    return (List<RequestMappingInfoHandlerMapping>) field.get(bean);
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+    }
+}

--- a/microcoffeeoncloud-location/src/main/resources/application.properties
+++ b/microcoffeeoncloud-location/src/main/resources/application.properties
@@ -15,3 +15,6 @@ spring.config.import=optional:configserver:
 spring.cloud.config.fail-fast=true
 # Workaround in Spring Cloud 2020.0.0 (fixed in 2020.0.1)
 #spring.cloud.config.profile=${spring.profiles.active}
+
+# Workaround for SpringFox 3 and Spring Boot 2.6. Also see Springfox3SpringBoot26Config.
+spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -16,3 +16,6 @@ spring.cloud.config.fail-fast=false
 
 # Disable Eureka client
 eureka.client.enabled=false
+
+# Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
+spring.mongodb.embedded.version=3.0.0

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-slim
+FROM openjdk:11.0.13-slim
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.1</version>
         <relativePath/>
     </parent>
 
@@ -30,9 +30,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
 
-        <modelmapper.version>2.4.4</modelmapper.version>
+        <modelmapper.version>2.4.5</modelmapper.version>
         <springfox.version>3.0.0</springfox.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/Springfox3SpringBoot26Config.java
@@ -1,0 +1,69 @@
+package study.microcoffee.order;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
+
+/**
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy.
+ * <p>
+ * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
+ * in <code>application.properties</code> as follows.
+ *
+ * <pre>
+ * spring.mvc.pathmatch.matching-strategy=ant-path-matcher
+ * </pre>
+ *
+ * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
+ * from Springfox to Springdoc.
+ *
+ * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
+ * @see <a href=
+ *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
+ *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>
+ */
+@Configuration
+public class Springfox3SpringBoot26Config {
+
+    @Bean
+    public BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+        return new BeanPostProcessor() {
+
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof WebMvcRequestHandlerProvider || bean instanceof WebFluxRequestHandlerProvider) {
+                    customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+                }
+                return bean;
+            }
+
+            private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings) {
+                List<T> copy = mappings.stream().filter(mapping -> mapping.getPatternParser() == null).collect(Collectors.toList());
+                mappings.clear();
+                mappings.addAll(copy);
+            }
+
+            @SuppressWarnings("unchecked")
+            private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+                try {
+                    Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+                    field.setAccessible(true); // NOSONAR Allow in workaround
+                    return (List<RequestMappingInfoHandlerMapping>) field.get(bean);
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+    }
+}

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/Springfox3SpringBoot26Config.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/Springfox3SpringBoot26Config.java
@@ -15,8 +15,9 @@ import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
 import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
 
 /**
- * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out actuator controllers which don't respect
- * spring.mvc.pathmatch.matching-strategy.
+ * Configuration class to hack Springfox WebMvcRequestHandlerProvider to filter out Actuator controllers which don't respect
+ * spring.mvc.pathmatch.matching-strategy. The code is copied from
+ * <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>.
  * <p>
  * This configuration class complements reverting the matching strategy spring.mvc.pathmatch.matching-strategy to ant-path-matcher
  * in <code>application.properties</code> as follows.
@@ -28,7 +29,6 @@ import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
  * This configuration is needed until a final fix is applied, either and preferably 1) Springfox fixes the issue, or 2) Migrate away
  * from Springfox to Springdoc.
  *
- * @see <a href="https://github.com/springfox/springfox/issues/3462">Springfox issue 3462</a>
  * @see <a href=
  *      "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc">Spring-Boot-2.6-Release-Notes
  *      pathpattern-based-path-matching-strategy-for-spring-mvc</a>

--- a/microcoffeeoncloud-order/src/main/resources/application.properties
+++ b/microcoffeeoncloud-order/src/main/resources/application.properties
@@ -19,3 +19,6 @@ spring.config.import=optional:configserver:
 spring.cloud.config.fail-fast=true
 # Workaround in Spring Cloud 2020.0.0 (fixed in 2020.0.1)
 #spring.cloud.config.profile=${spring.profiles.active}
+
+# Workaround for SpringFox 3 and Spring Boot 2.6. Also see Springfox3SpringBoot26Config.
+spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -38,3 +38,6 @@ spring.security.oauth2.client.registration.order-service.provider=keycloak
 spring.security.oauth2.client.registration.order-service.client-id=order-serviceX
 spring.security.oauth2.client.registration.order-service.client-secret=123-abc-456-xyz
 spring.security.oauth2.client.registration.order-service.authorization-grant-type=client_credentials
+
+# Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
+spring.mongodb.embedded.version=3.0.0


### PR DESCRIPTION
- Upgraded Spring Boot 2.5.5 -> 2.6.1, Spring Cloud 2020.0.4 -> 2021.0.0, modelmapper 2.4.4 -> 2.4.5, bootstrap 5.1.0 -> 5.1.3 and gmavenplus-plugin 1.13.0 -> 1.13.1.
- Upgraded Docker images openjdk 11.0.12-slim -> 11.0.13-slim and mongo 5.0 -> 5.0.4.
- Spring Cloud 2021.0.0 fix: Defined spring_cloud_config_server_git_default-label=master (default is now main).
- Added workaround for Springfox 3 to work with Spring Boot 2.6.
- Added spring.mongodb.embedded.version property now required by Spring Boot 2.6.