### PR TITLE
Fix setup gcloud deprecations

### DIFF
--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -12,12 +12,18 @@ jobs:
     name: Create GKE cluster
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/marketplace/actions/authenticate-to-google-cloud
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
+
       # https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ env.GKE_PROJECT }}
-          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Display current gcloud environment
         run: |-

--- a/.github/workflows/delete-cluster-gke.yml
+++ b/.github/workflows/delete-cluster-gke.yml
@@ -12,12 +12,18 @@ jobs:
     name: Delete GKE cluster
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/marketplace/actions/authenticate-to-google-cloud
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
+
       # https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ env.GKE_PROJECT }}
-          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
 
       - name: Display current gcloud environment
         run: |-

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -23,13 +23,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      # https://github.com/marketplace/actions/authenticate-to-google-cloud
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
+
       # https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ env.GKE_PROJECT }}
-          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
-          export_default_credentials: true
 
       - name: Display current gcloud environment
         run: |-
@@ -37,7 +42,7 @@ jobs:
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
-        uses: google-github-actions/get-gke-credentials@main
+        uses: google-github-actions/get-gke-credentials@v0
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -25,6 +25,8 @@ jobs:
           gcloud info
           printenv
           cat $GOOGLE_APPLICATION_CREDENTIALS
+          echo ${{ secrets.GKE_SRVGHA_KEY }} | base64 -d > $GITHUB_WORKSPACE/gke-srvgha-key.json
+          cat $GITHUB_WORKSPACE/gke-srvgha-key.json
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -14,31 +14,24 @@ jobs:
     steps:
       # https://github.com/marketplace/actions/authenticate-to-google-cloud
       - id: auth
+        name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}'
-
-      - name: Display current gcloud environment 1
-        run: |-
-          gcloud info
-          printenv
 
       # https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ env.GKE_PROJECT }}
-#          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
-#          export_default_credentials: true
 
-      - name: Display current gcloud environment 2
+      - name: Display current gcloud environment
         run: |-
           gcloud info
-          printenv
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
-        uses: google-github-actions/get-gke-credentials@main
+        uses: google-github-actions/get-gke-credentials@v0
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -24,6 +24,7 @@ jobs:
         run: |-
           gcloud info
           printenv
+          cat $GOOGLE_APPLICATION_CREDENTIALS
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -12,21 +12,29 @@ jobs:
     name: Undeploy from GKE cluster
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/marketplace/actions/authenticate-to-google-cloud
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}'
+
+      - name: Display current gcloud environment 1
+        run: |-
+          gcloud info
+          printenv
+
       # https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ env.GKE_PROJECT }}
-          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
-          export_default_credentials: true
+#          service_account_key: ${{ secrets.GKE_SRVGHA_KEY }}
+#          export_default_credentials: true
 
-      - name: Display current gcloud environment
+      - name: Display current gcloud environment 2
         run: |-
           gcloud info
           printenv
-          cat $GOOGLE_APPLICATION_CREDENTIALS
-          echo ${{ secrets.GKE_SRVGHA_KEY }} | base64 -d > $GITHUB_WORKSPACE/gke-srvgha-key.json
-          cat $GITHUB_WORKSPACE/gke-srvgha-key.json
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file


### PR DESCRIPTION
- Changed GitHub actions to use google-github-actions/auth instead of deprecated service_account_key and export_default_credentials parameteres in google-github-actions/setup-gcloud.
