### PR TITLE
Springboot 2.7.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,7 +1887,7 @@ and add the last line:
 
 :bulb: On Windows, the location of the Ubuntu file system is `%LOCALAPPDATA%\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\ext4.vhdx` (or similar).
 
-#### <a name="installing-docker-on-wsl"></a>Installing WSL on WSL
+#### <a name="installing-docker-on-wsl"></a>Installing Docker on WSL
 
 ##### Installing Docker
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:16.1.0
+FROM jboss/keycloak:16.1.1
 
 COPY --chown=jboss src/main/scripts/*.sh /opt/microcoffee/scripts/
 COPY --chown=jboss src/main/keycloak/*.json /opt/microcoffee/keycloak/

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -12,7 +12,7 @@
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <keytool-maven-plugin.version>1.5</keytool-maven-plugin.version>
+        <keytool-maven-plugin.version>1.6</keytool-maven-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
 
         <!-- VM host IP -->

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,11 +34,11 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,13 +34,13 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
-        <springdoc-openapi.version>1.6.4</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
-        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SecurityConfig.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SecurityConfig.java
@@ -1,17 +1,18 @@
 package study.microcoffee.creditrating;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * Configuration class for Spring Security.
  */
-@EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@Configuration
+public class SecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity httpSecurity) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity //
             .cors() // Bypasses the authorization checks for OPTIONS requests
             .and() //
@@ -20,5 +21,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .and() //
             .oauth2ResourceServer() //
             .jwt();
+        return httpSecurity.build();
     }
 }

--- a/microcoffeeoncloud-creditrating/src/test/java/study/microcoffee/creditrating/api/CreditRatingControllerTest.java
+++ b/microcoffeeoncloud-creditrating/src/test/java/study/microcoffee/creditrating/api/CreditRatingControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import study.microcoffee.creditrating.SecurityConfig;
 import study.microcoffee.creditrating.SecurityTestConfig;
 import study.microcoffee.creditrating.behavior.ServiceBehaviorFactory;
 import study.microcoffee.creditrating.domain.CreditRating;
@@ -30,7 +31,7 @@ import study.microcoffee.creditrating.logging.HttpLoggingFilterTestConfig;
 @WebMvcTest(CreditRatingController.class)
 @ImportAutoConfiguration(RefreshAutoConfiguration.class)
 @TestPropertySource("/application-test.properties")
-@Import({ HttpLoggingFilterTestConfig.class, SecurityTestConfig.class })
+@Import({ HttpLoggingFilterTestConfig.class, SecurityTestConfig.class, SecurityConfig.class })
 class CreditRatingControllerTest {
 
     private static final String SERVICE_PATH = "/api/coffeeshop/creditrating/{customerId}";

--- a/microcoffeeoncloud-creditrating/src/test/java/study/microcoffee/creditrating/health/HealthCheckControllerTest.java
+++ b/microcoffeeoncloud-creditrating/src/test/java/study/microcoffee/creditrating/health/HealthCheckControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import study.microcoffee.creditrating.SecurityConfig;
 import study.microcoffee.creditrating.SecurityTestConfig;
 
 /**
@@ -18,7 +19,7 @@ import study.microcoffee.creditrating.SecurityTestConfig;
  */
 @WebMvcTest(HealthCheckController.class)
 @TestPropertySource("/application-test.properties")
-@Import(SecurityTestConfig.class)
+@Import({ SecurityTestConfig.class, SecurityConfig.class })
 class HealthCheckControllerTest {
 
     @Autowired

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5.0.5
+FROM mongo:5.0.8
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5.0.8
+FROM mongo:5.0.9
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -11,12 +11,12 @@
     <properties>
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>3.0.9</groovy.version>
-        <mongo-java-driver.version>3.12.10</mongo-java-driver.version>
+        <groovy.version>3.0.11</groovy.version>
+        <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
 
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,11 +34,11 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,16 +34,16 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
         <bootstrap.version>5.1.3</bootstrap.version>
-        <springdoc-openapi.version>1.6.4</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>1.10.1</wro4j-maven-plugin.version>
 

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -34,12 +34,12 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
         <bootstrap.version>5.1.3</bootstrap.version>
-        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -32,10 +32,10 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <java-jwt.version>3.18.3</java-jwt.version>
+        <java-jwt.version>3.19.2</java-jwt.version>
 
         <!-- Plugin versions -->
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,10 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
-
-        <!-- Needed until Spring Boot 2.7.0 is released -->
-        <de.flapdoodle.embed.mongo.version>3.3.0</de.flapdoodle.embed.mongo.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
         <!-- 3.2.0 and higher gives unexpected test result (test is now disabled)
             Expected, but unable to find:
@@ -47,11 +44,11 @@
             < GET /api/coffeeshop/nearest/{latitude}/{longitude}/{maxdistance}  QueryParameters[]  PathParameters[latitude, longitude, maxdistance]  HeaderParameters[]  Produces[]  Consumes[] >
          -->
         <hikaku.version>3.3.0</hikaku.version>
-        <springdoc-openapi.version>1.6.4</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 
@@ -85,13 +82,6 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>de.flapdoodle.embed</groupId>
-                <artifactId>de.flapdoodle.embed.mongo</artifactId>
-                <version>${de.flapdoodle.embed.mongo.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
         <!-- 3.2.0 and higher gives unexpected test result (test is now disabled)
             Expected, but unable to find:
@@ -44,7 +44,7 @@
             < GET /api/coffeeshop/nearest/{latitude}/{longitude}/{maxdistance}  QueryParameters[]  PathParameters[latitude, longitude, maxdistance]  HeaderParameters[]  Produces[]  Consumes[] >
          -->
         <hikaku.version>3.3.0</hikaku.version>
-        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/SwaggerConfig.java
+++ b/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/SwaggerConfig.java
@@ -2,6 +2,7 @@ package study.microcoffee.location;
 
 import org.springdoc.core.SpringDocConfigProperties;
 import org.springdoc.core.SpringDocConfiguration;
+import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -19,5 +20,10 @@ public class SwaggerConfig {
     @Bean
     public SpringDocConfigProperties springDocConfigProperties() {
         return new SpringDocConfigProperties();
+    }
+
+    @Bean
+    public ObjectMapperProvider objectMapperProvider(SpringDocConfigProperties springDocConfigProperties) {
+        return new ObjectMapperProvider(springDocConfigProperties);
     }
 }

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
-spring.mongodb.embedded.version=3.0.0
+spring.mongodb.embedded.version=3.4.5

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -34,10 +34,10 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
 
         <modelmapper.version>3.1.0</modelmapper.version>
-        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0</version>
         <relativePath/>
     </parent>
 
@@ -34,17 +34,14 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
 
-        <!-- Needed until Spring Boot 2.7.0 is released -->
-        <de.flapdoodle.embed.mongo.version>3.3.0</de.flapdoodle.embed.mongo.version>
-
-        <modelmapper.version>3.0.0</modelmapper.version>
-        <springdoc-openapi.version>1.6.4</springdoc-openapi.version>
+        <modelmapper.version>3.1.0</modelmapper.version>
+        <springdoc-openapi.version>1.6.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
 
@@ -96,13 +93,6 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>de.flapdoodle.embed</groupId>
-                <artifactId>de.flapdoodle.embed.mongo</artifactId>
-                <version>${de.flapdoodle.embed.mongo.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
@@ -1,14 +1,15 @@
 package study.microcoffee.order;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity httpSecurity) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity //
             .csrf().disable() //
             .authorizeRequests() //
@@ -16,5 +17,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         // .and() //
         // .oauth2Client() // Only needed for the authorization code grant flow which we don't use.
         ;
+        return httpSecurity.build();
     }
 }

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import study.microcoffee.order.CharacterEncodingFilterTestConfig;
+import study.microcoffee.order.SecurityConfig;
 import study.microcoffee.order.SecurityTestConfig;
 import study.microcoffee.order.common.logging.HttpLoggingFilterTestConfig;
 import study.microcoffee.order.repository.MenuRepository;
@@ -24,7 +25,8 @@ import study.microcoffee.order.repository.MenuRepository;
  */
 @WebMvcTest(MenuController.class)
 @TestPropertySource("/application-test.properties")
-@Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class, SecurityTestConfig.class })
+@Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class, SecurityTestConfig.class,
+    SecurityConfig.class })
 class MenuControllerTest {
 
     private static final String SERVICE_PATH = "/api/coffeeshop/menu";

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import study.microcoffee.order.CharacterEncodingFilterTestConfig;
+import study.microcoffee.order.SecurityConfig;
 import study.microcoffee.order.SecurityTestConfig;
 import study.microcoffee.order.api.order.model.OrderModel;
 import study.microcoffee.order.common.logging.HttpLoggingFilterTestConfig;
@@ -41,7 +42,8 @@ import study.microcoffee.order.repository.OrderRepository;
  */
 @WebMvcTest(OrderController.class)
 @TestPropertySource("/application-test.properties")
-@Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class, SecurityTestConfig.class })
+@Import({ HttpLoggingFilterTestConfig.class, CharacterEncodingFilterTestConfig.class, SecurityTestConfig.class,
+    SecurityConfig.class })
 class OrderControllerTest {
 
     private static final String POST_SERVICE_PATH = "/api/coffeeshop/{coffeeShopId}/order";

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/health/HealthCheckControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/health/HealthCheckControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import study.microcoffee.order.SecurityConfig;
 import study.microcoffee.order.SecurityTestConfig;
 
 /**
@@ -18,7 +19,7 @@ import study.microcoffee.order.SecurityTestConfig;
  */
 @WebMvcTest(HealthCheckController.class)
 @TestPropertySource("/application-test.properties")
-@Import(SecurityTestConfig.class)
+@Import({ SecurityTestConfig.class, SecurityConfig.class })
 class HealthCheckControllerTest {
 
     @Autowired


### PR DESCRIPTION
- Upgraded Spring Boot 2.6.3 -> 2.7.0, Spring Cloud 2021.0.0 -> 2021.0.2 + other dependencies and plugins.
- Upgraded Docker images jboss/keycloak 16.1.0 -> 16.1.1 and mongo 5.0.5 -> 5.0.8.
- Replaced deprecated WebSecurityConfigurerAdapter by SecurityFilterChain beans.
- Removed dependency management of de.flapdoodle.embed.mongo workaround no longer needed with Spring Boot 2.7.