### PR TITLE
Java image spring boot 275 upgrade

### DIFF
--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -14,9 +14,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <keytool-maven-plugin.version>1.6</keytool-maven-plugin.version>
-        <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
 
         <!-- VM host IP -->
         <vmHostIp>192.168.99.100</vmHostIp>

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
@@ -6,6 +6,6 @@ COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
     && find / -iname "cacerts" \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-creditrating/docker-compose.yml
+++ b/microcoffeeoncloud-creditrating/docker-compose.yml
@@ -18,11 +18,11 @@ services:
 networks:
     microcoffee:
     authserver:
-        external:
-            name: microcoffeeoncloud-authserver_authserver
+        name: microcoffeeoncloud-authserver_authserver
+        external: true
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
+        name: microcoffeeoncloud-configserver_configserver
+        external: true
     discovery:
-        external:
-            name: microcoffeeoncloud-discovery_discovery
+        name: microcoffeeoncloud-discovery_discovery
+        external: true

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
-        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.12</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5.0.9
+FROM mongo:6.0.2
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,11 +13,11 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>3.0.11</groovy.version>
+        <groovy.version>3.0.13</groovy.version>
         <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
 
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
+        <gmavenplus-plugin.version>2.1.0</gmavenplus-plugin.version>
         <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-discovery/docker-compose.yml
+++ b/microcoffeeoncloud-discovery/docker-compose.yml
@@ -18,6 +18,5 @@ services:
 networks:
     discovery:
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
-            
+        name: microcoffeeoncloud-configserver_configserver
+        external: true

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-gateway/docker-compose-gateway-only.yml
+++ b/microcoffeeoncloud-gateway/docker-compose-gateway-only.yml
@@ -18,9 +18,8 @@ services:
 networks:
     microcoffee:
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
+        name: microcoffeeoncloud-configserver_configserver
+        external: true
     discovery:
-        external:
-            name: microcoffeeoncloud-discovery_discovery
-            
+        name: microcoffeeoncloud-discovery_discovery
+        external: true

--- a/microcoffeeoncloud-gateway/docker-compose.yml
+++ b/microcoffeeoncloud-gateway/docker-compose.yml
@@ -85,12 +85,11 @@ volumes:
 networks:
     microcoffee:
     authserver:
-        external:
-            name: microcoffeeoncloud-authserver_authserver
+        name: microcoffeeoncloud-authserver_authserver
+        external: true
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
+        name: microcoffeeoncloud-configserver_configserver
+        external: true
     discovery:
-        external:
-            name: microcoffeeoncloud-discovery_discovery
-        
+        name: microcoffeeoncloud-discovery_discovery
+        external: true

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,12 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
-        <bootstrap.version>5.1.3</bootstrap.version>
-        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
+        <bootstrap.version>5.2.2</bootstrap.version>
+        <springdoc-openapi.version>1.6.12</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -32,7 +32,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <java-jwt.version>3.19.2</java-jwt.version>
+        <java-jwt.version>4.2.1</java-jwt.version>
 
         <!-- Plugin versions -->
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-location/docker-compose.yml
+++ b/microcoffeeoncloud-location/docker-compose.yml
@@ -36,9 +36,8 @@ volumes:
 networks:
     microcoffee:
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
+        name: microcoffeeoncloud-configserver_configserver
+        external: true
     discovery:
-        external:
-            name: microcoffeeoncloud-discovery_discovery
- 
+        name: microcoffeeoncloud-discovery_discovery
+        external: true

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
         <!-- 3.2.0 and higher gives unexpected test result (test is now disabled)
             Expected, but unable to find:
@@ -44,7 +44,7 @@
             < GET /api/coffeeshop/nearest/{latitude}/{longitude}/{maxdistance}  QueryParameters[]  PathParameters[latitude, longitude, maxdistance]  HeaderParameters[]  Produces[]  Consumes[] >
          -->
         <hikaku.version>3.3.0</hikaku.version>
-        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.12</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
-spring.mongodb.embedded.version=3.4.5
+spring.mongodb.embedded.version=3.4.0

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:17.0.2-slim
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /usr/local/openjdk-17/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]
 

--- a/microcoffeeoncloud-order/docker-compose.yml
+++ b/microcoffeeoncloud-order/docker-compose.yml
@@ -53,11 +53,11 @@ volumes:
 networks:
     microcoffee:
     authserver:
-        external:
-            name: microcoffeeoncloud-authserver_authserver
+        name: microcoffeeoncloud-authserver_authserver
+        external: true
     configserver:
-        external:
-            name: microcoffeeoncloud-configserver_configserver
+        name: microcoffeeoncloud-configserver_configserver
+        external: true
     discovery:
-        external:
-            name: microcoffeeoncloud-discovery_discovery
+        name: microcoffeeoncloud-discovery_discovery
+        external: true

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -34,10 +34,10 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.3</spring-cloud.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
 
         <modelmapper.version>3.1.0</modelmapper.version>
-        <springdoc-openapi.version>1.6.9</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.12</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -40,4 +40,4 @@ spring.security.oauth2.client.registration.order-service.client-secret=123-abc-4
 spring.security.oauth2.client.registration.order-service.authorization-grant-type=client_credentials
 
 # Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
-spring.mongodb.embedded.version=3.0.0
+spring.mongodb.embedded.version=3.4.0


### PR DESCRIPTION
- Migrated from deprecated openjdk to eclipse-temurin image.
- Upgraded Spring Boot 2.7.0 -> 2.7.5, Spring Cloud 2021.0.3 -> 2021.0.4, springdoc-openapi-ui 1.6.9 -> 1.6.12, bootstrap 5.1.3 -> 5.2.2, java-jwt 3.19.2 -> 4.2.1, gmavenplus-plugin 1.13.1 -> 2.1.0 + some more plugins.
- Upgraded Docker image mongo 5.0.9 -> 6.0.2.
- Changed spring.mongodb.embedded.version to 3.4.0 after experiences unstable test executions with versions > 3.4.0.
- Fixed 'network.external.name is deprecated in favor of network.name' in docker-compose files.