### PR TITLE
Fabric8 docker maven plugin migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1921,7 +1921,7 @@ Verify the installation.
 
 ##### Add DOCKER_HOST on Windows
 
-To make the docker daemon available for tools like `dockerfile-maven-plugin` on Windows, add the environment variable:
+To make the docker daemon available for tools like Fabric8 `docker-maven-plugin` on Windows, add the environment variable:
 
     DOCKER_HOST=tcp://localhost:2375
 

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -13,7 +13,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
@@ -38,9 +38,29 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                        <retries>10</retries>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -77,12 +97,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -90,16 +106,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -112,12 +118,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -53,9 +53,6 @@
                                         <tag>${project.version}</tag>
                                         <tag>latest</tag>
                                     </tags>
-                                    <args>
-                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                                    </args>
                                 </build>
                             </image>
                         </images>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
@@ -158,9 +158,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -220,15 +239,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -236,16 +248,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -258,12 +260,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>
@@ -290,7 +288,6 @@
                 </plugins>
             </build>
         </profile>
-
 
         <!-- Generate code coverage: mvn clean verify -Pcoverage -->
         <profile>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -39,7 +39,7 @@
         <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
@@ -206,9 +206,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -267,15 +286,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -283,16 +295,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -305,12 +307,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -57,9 +57,6 @@
                                         <tag>${project.version}</tag>
                                         <tag>latest</tag>
                                     </tags>
-                                    <args>
-                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                                    </args>
                                 </build>
                             </image>
                         </images>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -16,7 +16,7 @@
         <groovy.version>4.0.8</groovy.version>
         <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
 
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>2.1.0</gmavenplus-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
 
@@ -42,9 +42,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -132,12 +151,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -145,16 +160,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -167,12 +172,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -23,15 +23,6 @@
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>
 
-    <dependencies>
-         <!-- Internal projects -->
-        <dependency>
-            <groupId>study.microcoffeeoncloud</groupId>
-            <artifactId>microcoffeeoncloud-certificates</artifactId>
-            <version>${microcoffeeoncloud-certificates.version}</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -125,14 +116,19 @@
                         <id>unpack-keystore</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>unpack</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>microcoffeeoncloud-certificates</includeArtifactIds>
-                            <includes>**/microcoffee.study.p12,**/wildcard.default.p12</includes>
-                            <outputDirectory>${project.build.directory}/keystore</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>study.microcoffeeoncloud</groupId>
+                                    <artifactId>microcoffeeoncloud-certificates</artifactId>
+                                    <version>${microcoffeeoncloud-certificates.version}</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/keystore</outputDirectory>
+                                    <includes>**/microcoffee.study.p12,**/wildcard.default.p12</includes>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
@@ -170,9 +170,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -231,15 +250,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -247,16 +259,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -269,12 +271,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -42,7 +42,7 @@
         <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>1.10.1</wro4j-maven-plugin.version>
@@ -177,9 +177,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -320,15 +339,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -336,16 +348,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -358,12 +360,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -41,7 +41,7 @@
         <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
@@ -193,9 +193,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -254,15 +273,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -270,16 +282,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -292,12 +294,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -40,7 +40,7 @@
         <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>
@@ -289,9 +289,28 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco-maven-plugin.version}</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <images>
+                            <image>
+                                <name>${docker.image.prefix}/${project.artifactId}</name>
+                                <alias>dockerfile</alias>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <tags>
+                                        <tag>${project.version}</tag>
+                                        <tag>latest</tag>
+                                    </tags>
+                                    <args>
+                                        <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -339,20 +358,13 @@
     <profiles>
         <!-- To build image: mvn clean package -Pbuild -->
         <!-- To build image + push image to Docker Hub: mvn clean package -Pbuild,push -->
-        <profile>
+         <profile>
             <id>build</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                            <buildArgs>
-                                <JAR_FILE>${project.artifactId}-${project.version}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>
@@ -360,16 +372,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>tag-image-latest</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <tag>latest</tag>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -382,12 +384,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -283,12 +283,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>${dockerfile-maven-plugin.version}</version>
-                </plugin>
-
-                <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${docker-maven-plugin.version}</version>


### PR DESCRIPTION
-  Migrated from Spotify dockerfile-maven-plugin (dead project) to Fabric8 docker-maven-plugin.
-  Changed maven-dependency-plugin config from unpack-dependencies to unpack to avoid project dependency which may cause problems when deploying to cluster from GitHub action. (Depends on Maven caching.)