### PR TITLE
Springboot 303 deps upgrade

### DIFF
--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:20.0.3
+FROM quay.io/keycloak/keycloak:21.0.0
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,8 +13,8 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.8</groovy.version>
-        <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
+        <groovy.version>4.0.9</groovy.version>
+        <mongo-java-driver.version>3.12.12</mongo-java-driver.version>
 
         <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>2.1.0</gmavenplus-plugin.version>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 
@@ -32,7 +32,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <java-jwt.version>4.2.2</java-jwt.version>
+        <java-jwt.version>4.3.0</java-jwt.version>
 
         <!-- Plugin versions -->
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.4.1</flapdoodle-embed-mongo.version>
+        <flapdoodle-embed-mongo.version>4.6.0</flapdoodle-embed-mongo.version>
         <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/download-center/community/releases)
-de.flapdoodle.mongodb.embedded.version=6.0.3
+de.flapdoodle.mongodb.embedded.version=6.0.4

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>2.7.9</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
- Upgraded Spring Boot 3.0.2 -> 3.0.3, java-jwt 4.2.2 -> 4.3.0 and flapdoodle-embed-mongo 4.4.1 -> 4.6.0.
- Upgraded Docker image keycloak/keycloak 20.0.3 -> 21.0.0.