### PR TITLE
Springboot 305 upgrade

### DIFF
--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -100,8 +100,6 @@ jobs:
           kubectl delete deployment order --ignore-not-found
           kubectl wait --for=delete pod -l app=order --timeout=60s
 
-          netstat -an
-          kubectl get pods
           kubectl apply -f microcoffeeoncloud-gateway/k8s-service-gke.yml
           kubectl apply -f microcoffeeoncloud-location/k8s-service-gke.yml
           kubectl apply -f microcoffeeoncloud-order/k8s-service-gke.yml

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Display current gcloud environment
         run: |-
           gcloud info
-          netstat -an
 
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
@@ -101,6 +100,8 @@ jobs:
           kubectl delete deployment order --ignore-not-found
           kubectl wait --for=delete pod -l app=order --timeout=60s
 
+          netstat -an
+          kubectl get pods
           kubectl apply -f microcoffeeoncloud-gateway/k8s-service-gke.yml
           kubectl apply -f microcoffeeoncloud-location/k8s-service-gke.yml
           kubectl apply -f microcoffeeoncloud-order/k8s-service-gke.yml

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Date | Change
 18.11.2022 | Replaced Docker Toolbox with Docker Desktop for local building and testing. Updated Minikube doc. General brush-up of outdated info.
 28.11.2022 | Updated section on API testing with Gatling. Migrated from Scala IDE to IntelliJ.
 28.12.2022 | Upgraded to Spring Boot 3.0.1 and Spring Cloud 2022.0.0.
+26.03.2023 | Upgraded to Spring Boot 3.0.5. Microcoffee now requires OpenSSL 3.x to generate the self-signed certificates.
 
 ## Contents
 
@@ -171,7 +172,7 @@ For building and testing the application on Windows, Docker Desktop with the WSL
 
 In addition, you'll need the basic Java development tools (IDE w/ Java 17 and Maven) installed on your development machine.
 
-You will also need OpenSSL to create a self-signed wildcard certificate. Finally, [curl](https://curl.se/) and [jq](https://stedolan.github.io/jq/) are needed.
+You will also need OpenSSL 3.x to create a self-signed wildcard certificate. Finally, [curl](https://curl.se/) and [jq](https://stedolan.github.io/jq/) are needed.
 
 :warning: Java keytool won't work because it doesn't support wildcard host names as SAN (Subject Alternative Name) values.
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:21.0.0
+FROM quay.io/keycloak/keycloak:21.0.1
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -13,8 +13,10 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>
@@ -31,12 +33,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${maven-dependency-plugin.version}</version>
-                </plugin>
-
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
@@ -58,6 +54,24 @@
                         </images>
                         <retries>10</retries>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -131,6 +131,20 @@
                                 </configuration>
                             </execution>
 
+                            <!-- List openssl version -->
+                            <execution>
+                                <id>list-openssl-version</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <arguments>
+                                        <argument>version</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+
                             <!-- Generate private keys and certificates -->
                             <execution>
                                 <id>generate-key-and-cert-microcoffee-study</id>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -15,8 +15,10 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <keytool-maven-plugin.version>1.6</keytool-maven-plugin.version>
-        <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+        <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 
         <!-- VM host IP -->
         <vmHostIp>192.168.99.100</vmHostIp>
@@ -35,6 +37,18 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>keytool-maven-plugin</artifactId>
                     <version>${keytool-maven-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -19,6 +19,7 @@
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 
         <!-- VM host IP -->
         <vmHostIp>192.168.99.100</vmHostIp>
@@ -49,6 +50,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${maven-install-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 
@@ -36,10 +36,10 @@
 
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
-        <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
+        <springdoc-openapi.version>2.0.4</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:6.0.4
+FROM mongo:6.0.5
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,7 +1,8 @@
 FROM mongo:6.0.4
 WORKDIR /
 COPY target/keystore/*.p12 ./
-RUN openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \
+RUN openssl version \
+    && openssl pkcs12 -in microcoffee.study.p12 -password pass:12345678 -nodes -out microcoffee.study-key.pem \
     && openssl pkcs12 -in wildcard.default.p12 -password pass:12345678 -nodes -out wildcard.default-key.pem \
     && chmod go+r *.pem \
     && rm microcoffee.study.p12 \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,12 +13,14 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.9</groovy.version>
+        <groovy.version>4.0.10</groovy.version>
         <mongo-java-driver.version>3.12.12</mongo-java-driver.version>
 
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>2.1.0</gmavenplus-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>
@@ -26,12 +28,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${maven-dependency-plugin.version}</version>
-                </plugin>
-
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
@@ -52,6 +48,24 @@
                             </image>
                         </images>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 
@@ -39,10 +39,10 @@
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
         <bootstrap.version>5.2.3</bootstrap.version>
-        <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
+        <springdoc-openapi.version>2.0.4</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>1.10.1</wro4j-maven-plugin.version>

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <relativePath/>
     </parent>
 
@@ -37,11 +37,11 @@
         <spring-cloud.version>2022.0.1</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.6.0</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.0.2</springdoc-openapi.version>
+        <flapdoodle-embed-mongo.version>4.6.2</flapdoodle-embed-mongo.version>
+        <springdoc-openapi.version>2.0.4</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/download-center/community/releases)
-de.flapdoodle.mongodb.embedded.version=6.0.4
+de.flapdoodle.mongodb.embedded.version=6.0.5

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.9</version>
+        <version>2.7.10</version>
         <relativePath/>
     </parent>
 
@@ -34,13 +34,13 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.6</spring-cloud.version>
 
         <modelmapper.version>3.1.1</modelmapper.version>
-        <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.15</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -308,6 +308,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>${sonar-maven-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     </properties>
 
     <modules>
@@ -23,4 +26,22 @@
         <module>microcoffeeoncloud-location</module>
         <module>microcoffeeoncloud-order</module>
     </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
- Upgraded Spring Boot 3.0.3 -> 3.0.5 + other deps.
- Added missing plugin management of jacoco-maven-plugin. 
- Added display of openssl version when generating certificates. 
- Upgraded mongo Docker image 6.0.4 -> 6.0.5. (Requires that the certificate is generated with OpenSSL 3.x.)
- Updated readme.