### PR TITLE
Upgrade springboot 313 deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
 

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Maven artifacts
         uses: actions/cache@v3

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:21.1.1
+FROM quay.io/keycloak/keycloak:22.0.3
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -13,8 +13,8 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
-        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -16,7 +16,7 @@
 
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
-        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,12 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -34,14 +34,14 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
 
-        <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:6.0.6
+FROM mongo:7.0.1
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,12 +13,12 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.12</groovy.version>
-        <mongo-java-driver.version>3.12.13</mongo-java-driver.version>
+        <groovy.version>4.0.15</groovy.version>
+        <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <gmavenplus-plugin.version>3.0.0</gmavenplus-plugin.version>
-        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
 

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,12 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -34,24 +34,24 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
 
-        <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version>
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
-        <bootstrap.version>5.2.3</bootstrap.version>
+        <bootstrap.version>5.3.1</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v18.16.0</node.version>
-        <npm.version>9.5.1</npm.version>
+        <node.version>v18.17.1</node.version>
+        <npm.version>9.6.7</npm.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
-        <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <frontend-maven-plugin.version>1.14.0</frontend-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>1.10.1</wro4j-maven-plugin.version>
 
         <!-- wro4j-maven-plugin version conflict fix. Use glob 7.2.0 instead of 7.2.3. See details below. -->

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -349,6 +349,7 @@
                     <wroFile>${project.build.directory}/wro/wro.xml</wroFile>
                     <extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
                     <ignoreMissingResources>false</ignoreMissingResources>
+                    <contextFolder>${basedir}/src/main/webapp/</contextFolder>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- Plugin versions -->
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -37,7 +37,7 @@
         <spring-cloud.version>2022.0.4</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.9.2</flapdoodle-embed-mongo.version>
+        <flapdoodle-embed-mongo.version>4.9.3</flapdoodle-embed-mongo.version>
         <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -34,16 +34,16 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
+        <spring-cloud.version>2022.0.4</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.6.2</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+        <flapdoodle-embed-mongo.version>4.9.2</flapdoodle-embed-mongo.version>
+        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/download-center/community/releases)
-de.flapdoodle.mongodb.embedded.version=6.0.5
+de.flapdoodle.mongodb.embedded.version=7.0.0

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jre-alpine
+FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.12</version>
+        <version>2.7.15</version>
         <relativePath/>
     </parent>
 
@@ -34,15 +34,15 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2021.0.7</spring-cloud.version>
+        <spring-cloud.version>2021.0.8</spring-cloud.version>
 
         <modelmapper.version>3.1.1</modelmapper.version>
         <springdoc-openapi.version>1.7.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     </properties>
 


### PR DESCRIPTION
- Upgraded Spring Boot 3.1.0 -> 3.1.3, Keycloak 21.1.1 -> 22.0.3, Mongo 6.0.6 -> 7.0.0 + other deps and plugins.
- Added .mvn folder in project root to kill Maven 4 warning about undefined root folder.