### PR TITLE
Order csrf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,11 +431,9 @@ After Microcoffee has started, navigate to the coffee shop to place your first c
 
 Centralized browsing of API documentation is available at the following URL:
 
-    https://host.docker.internal:8443/swagger-ui.html
+    https://localhost:8443/swagger-ui.html
 
 Select the spec of interest in the upper right corner.
-
-:point_right: To avoid a CORS issue, use `host.docker.internal` in stead of `localhost` in the Swagger URL.
 
 ### <a name="location-api"></a>Location API
 
@@ -614,13 +612,11 @@ Response:
 
 :white_check_mark: Must be run from `microcoffee-order` to find the JSON file `src\test\curl\order.json`.
 
-Due to the CSRF protection implemented by the Order API, the POST operation must provide a valid CSRF token in a cookie as well as in a header. To get a valid token, we first make a dummy call to the GET operation of the Order API. The CSRF token is extracted from the returned X-XSRF-TOKEN header.
+Due to the CSRF protection implemented by the Order API, the POST operation must provide a valid CSRF token in an `XSRF-TOKEN` cookie as well as in an `X-XSRF-TOKEN` header. To get a valid token, we first make a dummy call to the GET operation of the Order API. The CSRF token is then extracted from the returned `X-XSRF-TOKEN` header.
 
     :: Calls the GET operation and sets the environment variable CSRF-TOKEN with the current CSRF token.
-
     for /f "delims=" %I in ('curl -s -i http://localhost:8082/api/coffeeshop/1/order/123 ^| grep X-XSRF-TOKEN ^| sed -nr "s/X-XSRF-TOKEN: (.*)/\1/p"') do set CSRF-TOKEN=%I
     :: Test the Order API. Both with http and https.
-
     curl -i -H "Cookie: XSRF-TOKEN=%CSRF-TOKEN%" -H "X-XSRF-TOKEN: %CSRF-TOKEN%" -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json http://localhost:8082/api/coffeeshop/1/order
 
      curl -i --insecure -H "Cookie: XSRF-TOKEN=%CSRF-TOKEN%" -H "X-XSRF-TOKEN: %CSRF-TOKEN%" -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json https://localhost:8445/api/coffeeshop/1/order

--- a/README.md
+++ b/README.md
@@ -621,7 +621,6 @@ Due to the CSRF protection implemented by the Order API, the POST operation must
 
      curl -i --insecure -H "Cookie: XSRF-TOKEN=%CSRF-TOKEN%" -H "X-XSRF-TOKEN: %CSRF-TOKEN%" -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json https://localhost:8445/api/coffeeshop/1/order
 
-
 #### Get order details
 
 **Syntax**

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Date | Change
 11.05.2023 | Developed new frontend in ReactJS. (Old AngularJS frontend is still available.)
 18.05.2023 | Added screendumps of Microcoffee GUI in doc page.
 23.05.2023 | Upgraded to Spring Boot 3.1.0.
+16.10.2023 | Implemented CSRF protection in the Order API (POST operation).
 
 ## Contents
 
@@ -123,7 +124,7 @@ Contains the Menu and Order REST services. Provides APIs for reading the coffee 
 
 Order uses the CreditRating REST service as a backend service for checking if a customer is creditworthy when placing an order. CreditRating is an unreliable service, hence giving us an "excuse" to use Resilience4J for retrying service calls that fail.
 
-Order is an OAuth2 client and uses the [client credentials flow](https://auth0.com/docs/flows/client-credentials-flow) to access CreditRating.
+Order is an OAuth2 client and uses the [client credentials flow](https://auth0.com/docs/flows/client-credentials-flow) to access CreditRating. The API implements CSRF (Cross-Site Request Forgery) protection on the POST operation.
 
 #### microcoffeeoncloud-creditrating
 Contains an extremely simple credit rating service. Provides an API for reading the credit rating of a customer. Used by the Order service.
@@ -613,8 +614,17 @@ Response:
 
 :white_check_mark: Must be run from `microcoffee-order` to find the JSON file `src\test\curl\order.json`.
 
-    curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json http://localhost:8082/api/coffeeshop/1/order
-    curl -i --insecure -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json https://localhost:8445/api/coffeeshop/1/order
+Due to the CSRF protection implemented by the Order API, the POST operation must provide a valid CSRF token in a cookie as well as in a header. To get a valid token, we first make a dummy call to the GET operation of the Order API. The CSRF token is extracted from the returned X-XSRF-TOKEN header.
+
+    :: Calls the GET operation and sets the environment variable CSRF-TOKEN with the current CSRF token.
+
+    for /f "delims=" %I in ('curl -s -i http://localhost:8082/api/coffeeshop/1/order/123 ^| grep X-XSRF-TOKEN ^| sed -nr "s/X-XSRF-TOKEN: (.*)/\1/p"') do set CSRF-TOKEN=%I
+    :: Test the Order API. Both with http and https.
+
+    curl -i -H "Cookie: XSRF-TOKEN=%CSRF-TOKEN%" -H "X-XSRF-TOKEN: %CSRF-TOKEN%" -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json http://localhost:8082/api/coffeeshop/1/order
+
+     curl -i --insecure -H "Cookie: XSRF-TOKEN=%CSRF-TOKEN%" -H "X-XSRF-TOKEN: %CSRF-TOKEN%" -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d @src\test\curl\order.json https://localhost:8445/api/coffeeshop/1/order
+
 
 #### Get order details
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.3
+FROM quay.io/keycloak/keycloak:22.0.4
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
@@ -60,6 +60,7 @@ public class SwaggerConfig {
                 .name(CREDIT_RATING_TAG) //
                 .description("API to get the credit rating of a customer.")));
 
+        // If property is defined, override the content of the Servers drop-down list in the Swagger UI.
         if (serverListOverrideUrl != null) {
             openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
         }

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
@@ -3,6 +3,7 @@ package study.microcoffee.creditrating;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 
 /**
@@ -28,9 +30,12 @@ public class SwaggerConfig {
     public static final String CORRELATION_ID_HEADER = "Correlation-Id";
     public static final String BEARER_TOKEN_AUTH = "BearerToken";
 
+    @Value("${app.springdoc.serverListOverrideUrl:#{null}}")
+    private String serverOverrideUrl;
+
     @Bean
     public OpenAPI apiInfo() {
-        return new OpenAPI() //
+        OpenAPI openApi = new OpenAPI() //
             .info(new Info() //
                 .title("Credit Rating API") //
                 .description("API to get the credit rating of customers.") //
@@ -54,5 +59,11 @@ public class SwaggerConfig {
             .tags(List.of(new Tag() //
                 .name(CREDIT_RATING_TAG) //
                 .description("API to get the credit rating of a customer.")));
+
+        if (serverOverrideUrl != null) {
+            openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+        }
+
+        return openApi;
     }
 }

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/SwaggerConfig.java
@@ -31,7 +31,7 @@ public class SwaggerConfig {
     public static final String BEARER_TOKEN_AUTH = "BearerToken";
 
     @Value("${app.springdoc.serverListOverrideUrl:#{null}}")
-    private String serverOverrideUrl;
+    private String serverListOverrideUrl;
 
     @Bean
     public OpenAPI apiInfo() {
@@ -60,8 +60,8 @@ public class SwaggerConfig {
                 .name(CREDIT_RATING_TAG) //
                 .description("API to get the credit rating of a customer.")));
 
-        if (serverOverrideUrl != null) {
-            openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+        if (serverListOverrideUrl != null) {
+            openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
         }
 
         return openApi;

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/api/CreditRatingController.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/api/CreditRatingController.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +22,6 @@ import study.microcoffee.creditrating.domain.CreditRating;
  * <p>
  * <b>TODO:</b> Currently a hardcoded credit rating of 70 is always returned. Needs to make it dependent on the actual customer.
  */
-@CrossOrigin // Needed for Swagger/SpringDoc to work from gateway.
 @RefreshScope
 @RestController
 @RequestMapping(path = "/api/coffeeshop", produces = { MediaType.APPLICATION_JSON_VALUE })

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-gateway/app/src/CoffeeOrder.js
+++ b/microcoffeeoncloud-gateway/app/src/CoffeeOrder.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Container, Form, FormGroup, Input, Label } from 'reactstrap';
 import { OrderLine } from './OrderConfirmation';
 import { config } from './EnvConfig';
+import { useCookies} from 'react-cookie';
 
 const PrintJson = ({ data }) => (<div><pre>{JSON.stringify(data, null, 2)}</pre></div>);
 
@@ -24,6 +25,7 @@ const CoffeeOrder = () => {
     const [availableOptions, setAvailableOptions] = useState([]);
     const [displayedOption, setDisplayedOption] = useState('');
     const [orderList, setOrderList] = useState([]);
+    const [cookies] = useCookies(['XSRF-TOKEN']);
 
     useEffect(() => {
         console.log('NODE_ENV=' + process.env.NODE_ENV);
@@ -51,9 +53,11 @@ const CoffeeOrder = () => {
             method: 'POST',
             headers: {
                 'Accept': 'application/json',
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-XSRF-TOKEN': cookies['XSRF-TOKEN']
             },
-            body: JSON.stringify(order)
+            body: JSON.stringify(order),
+            credentials: 'include'
         })
             .then(response => response.json().then(json => ({
                 ok: response.ok,

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -50,7 +50,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <frontend-maven-plugin.version>1.14.0</frontend-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>2.1.1</wro4j-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-gateway/src/main/resources/application.properties
+++ b/microcoffeeoncloud-gateway/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.config.import=optional:configserver:
 spring.cloud.config.fail-fast=true
 
 # SpringDoc
+springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.urls[0].name=creditrating
 springdoc.swagger-ui.urls[0].url=/v3/api-docs/creditrating

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -35,7 +35,7 @@
         <java-jwt.version>4.4.0</java-jwt.version>
 
         <!-- Plugin versions -->
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -38,12 +38,12 @@
         <flapdoodle-embed-mongo.version>4.9.3</flapdoodle-embed-mongo.version>
         <spring-cloud.version>2023.0.0-M2</spring-cloud.version>
 
-        <modelmapper.version>3.1.1</modelmapper.version>
+        <modelmapper.version>3.2.0</modelmapper.version>
         <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -237,6 +237,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/HttpLoggingFilterConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/HttpLoggingFilterConfig.java
@@ -20,7 +20,7 @@ import study.microcoffee.order.common.logging.HttpLoggingFilter;
 @Configuration
 public class HttpLoggingFilterConfig {
 
-    @Value("${formatted.logging:false}")
+    @Value("${formatted.logging:true}")
     private boolean formattedLogging;
 
     @Bean

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity //
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll()) //
+            .authorizeHttpRequests(authorize -> authorize //
+                .anyRequest().permitAll()) //
             .csrf(csrf -> csrf //
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // Allow XSRF-TOKEN cookie to be read
                 .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())) // Use Spring Security 5 default (non-BREACH)

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
@@ -4,15 +4,26 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
+import study.microcoffee.order.common.security.CookieCsrfFilter;
+
+/**
+ * Configuration class for Spring Security.
+ */
 @Configuration
 public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity //
-            .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll()) //
+            .csrf(csrf -> csrf //
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // Allow XSRF-TOKEN cookie to be read
+                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())) // Use Spring Security 5 default (non-BREACH)
+            .addFilterAfter(new CookieCsrfFilter(), BasicAuthenticationFilter.class);
         return httpSecurity.build();
     }
 }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SecurityConfig.java
@@ -8,7 +8,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
-import study.microcoffee.order.common.security.CookieCsrfFilter;
+import study.microcoffee.order.security.csrf.CsrfHeaderFilter;
 
 /**
  * Configuration class for Spring Security.
@@ -23,7 +23,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf //
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // Allow XSRF-TOKEN cookie to be read
                 .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())) // Use Spring Security 5 default (non-BREACH)
-            .addFilterAfter(new CookieCsrfFilter(), BasicAuthenticationFilter.class);
+            .addFilterAfter(new CsrfHeaderFilter(), BasicAuthenticationFilter.class);
         return httpSecurity.build();
     }
 }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
@@ -1,14 +1,17 @@
 package study.microcoffee.order;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.servers.Server;
 
 /**
  * Configuration class of Swagger.
@@ -24,6 +27,9 @@ public class SwaggerConfig {
 
     public static final String CORRELATION_ID_HEADER = "Correlation-Id";
 
+    @Value("${app.springdoc.serverListOverrideUrl:#{null}}")
+    private String serverOverrideUrl;
+
     @Bean
     public GroupedOpenApi menuApiGroup() {
         return GroupedOpenApi.builder() //
@@ -37,6 +43,10 @@ public class SwaggerConfig {
                     .contact(apiContact());
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
+
+                if (serverOverrideUrl != null) {
+                    openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+                }
             }).build();
     }
 
@@ -53,6 +63,10 @@ public class SwaggerConfig {
                     .contact(apiContact());
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
+
+                if (serverOverrideUrl != null) {
+                    openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+                }
             }).build();
     }
 

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
@@ -44,6 +44,7 @@ public class SwaggerConfig {
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
 
+                // If property is defined, override the content of the Servers drop-down list in the Swagger UI.
                 if (serverListOverrideUrl != null) {
                     openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
                 }
@@ -64,6 +65,7 @@ public class SwaggerConfig {
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
 
+                // If property is defined, override the content of the Servers drop-down list in the Swagger UI.
                 if (serverListOverrideUrl != null) {
                     openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
                 }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/SwaggerConfig.java
@@ -28,7 +28,7 @@ public class SwaggerConfig {
     public static final String CORRELATION_ID_HEADER = "Correlation-Id";
 
     @Value("${app.springdoc.serverListOverrideUrl:#{null}}")
-    private String serverOverrideUrl;
+    private String serverListOverrideUrl;
 
     @Bean
     public GroupedOpenApi menuApiGroup() {
@@ -44,8 +44,8 @@ public class SwaggerConfig {
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
 
-                if (serverOverrideUrl != null) {
-                    openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+                if (serverListOverrideUrl != null) {
+                    openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
                 }
             }).build();
     }
@@ -64,8 +64,8 @@ public class SwaggerConfig {
                 openApi.getComponents() //
                     .addParameters(CORRELATION_ID_HEADER, correlationIdHeader()); //
 
-                if (serverOverrideUrl != null) {
-                    openApi.servers(List.of(new Server().url(serverOverrideUrl)));
+                if (serverListOverrideUrl != null) {
+                    openApi.servers(List.of(new Server().url(serverListOverrideUrl)));
                 }
             }).build();
     }

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/menu/MenuController.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/menu/MenuController.java
@@ -16,7 +16,9 @@ import study.microcoffee.order.repository.MenuRepository;
 /**
  * Controller class of the Menu REST API for returning the coffee shop menu.
  */
-@CrossOrigin // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
+@CrossOrigin( // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
+    origins = "http://localhost:3000")
+//@CrossOrigin
 @RestController
 @RequestMapping(path = "/api/coffeeshop", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = SwaggerConfig.MENU_TAG, description = SwaggerConfig.MENU_DESCRIPTION)

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/menu/MenuController.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/menu/MenuController.java
@@ -16,9 +16,9 @@ import study.microcoffee.order.repository.MenuRepository;
 /**
  * Controller class of the Menu REST API for returning the coffee shop menu.
  */
-@CrossOrigin( // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
-    origins = "http://localhost:3000")
-//@CrossOrigin
+@CrossOrigin( //
+    origins = { "http://localhost:3000" } // Needed for React dev on port 3000.
+)
 @RestController
 @RequestMapping(path = "/api/coffeeshop", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = SwaggerConfig.MENU_TAG, description = SwaggerConfig.MENU_DESCRIPTION)

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/order/OrderController.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/order/OrderController.java
@@ -31,10 +31,11 @@ import study.microcoffee.order.repository.OrderRepository;
 /**
  * Controller class of the Order REST API for handling coffee orders.
  */
-@CrossOrigin( // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
+@CrossOrigin( //
+    origins = { "http://localhost:3000" }, // Needed for React dev on port 3000.
     exposedHeaders = { "Location" }, //
-    allowCredentials = "true", //
-    originPatterns = "*")
+    allowCredentials = "true" //
+)
 @RestController
 @RequestMapping(path = "/api/coffeeshop", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = SwaggerConfig.ORDER_TAG, description = SwaggerConfig.ORDER_DESCRIPTION)

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/order/OrderController.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/api/order/OrderController.java
@@ -31,7 +31,10 @@ import study.microcoffee.order.repository.OrderRepository;
 /**
  * Controller class of the Order REST API for handling coffee orders.
  */
-@CrossOrigin(exposedHeaders = "Location") // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
+@CrossOrigin( // Needed for Swagger/SpringDoc to work from gateway + React dev on port 3000.
+    exposedHeaders = { "Location" }, //
+    allowCredentials = "true", //
+    originPatterns = "*")
 @RestController
 @RequestMapping(path = "/api/coffeeshop", produces = MediaType.APPLICATION_JSON_VALUE)
 @Tag(name = SwaggerConfig.ORDER_TAG, description = SwaggerConfig.ORDER_DESCRIPTION)

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicWebClientFactory.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/creditrating/BasicWebClientFactory.java
@@ -33,7 +33,7 @@ public class BasicWebClientFactory {
             authorizedClientManager);
         oauth2Client.setDefaultClientRegistrationId("order-service");
 
-        HttpClient httpClient = JettyHttpClientFactory.createDefaultClient(timeout, new JettyHttpClientLogEnhancer(true));
+        HttpClient httpClient = JettyHttpClientFactory.createDefaultClient(timeout, new JettyHttpClientLogEnhancer(false));
 
         return WebClient.builder() //
             .apply(oauth2Client.oauth2Configuration()) //

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/security/csrf/CsrfHeaderFilter.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/security/csrf/CsrfHeaderFilter.java
@@ -1,0 +1,28 @@
+package study.microcoffee.order.security.csrf;
+
+import java.io.IOException;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet filter that sets a XSRF-TOKEN header. In Spring Security 6, this header is not set by default.
+ * <p>
+ * This solution is <a href="https://github.com/spring-projects/spring-security/issues/12141#issuecomment-1321345077"> recommended
+ * by Spring Security.</a>
+ */
+public class CsrfHeaderFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        response.setHeader(csrfToken.getHeaderName(), csrfToken.getToken());
+        filterChain.doFilter(request, response);
+    }
+}

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -84,7 +84,7 @@ class OrderControllerTest {
         given(creditRatingCustomerMock.getCreditRating(anyString())).willReturn(70);
 
         mockMvc.perform(post(POST_SERVICE_PATH, COFFEE_SHOP_ID) //
-            .with(csrf()) //
+            .with(csrf().asHeader()) //
             .content(toJson(orderModel)) //
             .contentType(MediaType.APPLICATION_JSON) //
             .header("Host", "somehost.no")) //
@@ -107,11 +107,27 @@ class OrderControllerTest {
         given(creditRatingCustomerMock.getCreditRating(anyString())).willReturn(20);
 
         mockMvc.perform(post(POST_SERVICE_PATH, COFFEE_SHOP_ID) //
-            .with(csrf()) //
+            .with(csrf().asHeader()) //
             .content(toJson(orderModel)) //
             .contentType(MediaType.APPLICATION_JSON)) //
             .andExpect(status().isPaymentRequired()) //
             .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN));
+    }
+
+    @Test
+    void createOrderWhenCsrfTokenIsInvalidShouldReturn403Forbidden() throws Exception {
+        OrderModel orderModel = OrderModel.builder() //
+            .type(new DrinkType("Latte", "Coffee")) //
+            .size("Small") //
+            .drinker("Dagbjørn") //
+            .selectedOptions(new String[] { "skimmed milk" }) //
+            .build();
+
+        mockMvc.perform(post(POST_SERVICE_PATH, COFFEE_SHOP_ID) //
+            .with(csrf().asHeader().useInvalidToken()) //
+            .content(toJson(orderModel)) //
+            .contentType(MediaType.APPLICATION_JSON)) //
+            .andExpect(status().isForbidden());
     }
 
     @Test

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -3,6 +3,7 @@ package study.microcoffee.order.api.order;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -83,6 +84,7 @@ class OrderControllerTest {
         given(creditRatingCustomerMock.getCreditRating(anyString())).willReturn(70);
 
         mockMvc.perform(post(POST_SERVICE_PATH, COFFEE_SHOP_ID) //
+            .with(csrf()) //
             .content(toJson(orderModel)) //
             .contentType(MediaType.APPLICATION_JSON) //
             .header("Host", "somehost.no")) //
@@ -105,6 +107,7 @@ class OrderControllerTest {
         given(creditRatingCustomerMock.getCreditRating(anyString())).willReturn(20);
 
         mockMvc.perform(post(POST_SERVICE_PATH, COFFEE_SHOP_ID) //
+            .with(csrf()) //
             .content(toJson(orderModel)) //
             .contentType(MediaType.APPLICATION_JSON)) //
             .andExpect(status().isPaymentRequired()) //

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerWebClientIT.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerWebClientIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -67,6 +68,7 @@ import study.microcoffee.order.domain.DrinkType;
  * by user frenchu to this post on stackoverflow</a>
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient(timeout = "60000") // Millisecs
 @AutoConfigureObservability
 @TestPropertySource(locations = "/application-test.properties", properties = "server.ssl.enabled=false")
 @ActiveProfiles("itest")


### PR DESCRIPTION
- Added servlet filter that adds a X-XSRF-TOKEN header to the HTTP response.
- Added CSRF support in CoffeeOrder frontend.
- Added fix on CSRF issue with Swagger by adding springdoc.swagger-ui.csrf.enabled=true.
- More CORS config in Order service to support CSRF with React frontend on localhost:3000.
- Implemented fix for Swagger issue on Docker by replacing host.docker.internal with localhost using an environment dependent app.springdoc.serverListOverrideUrl property.
- Changed CORS config on controllers to only apply to React dev on port 3000.
- Increased WebTestClient timeout from default 5 to 60 secs. 
- Updated keycloak 22.0.3 -> 22.0.4. 
- Updated modelmapper 3.1.1 -> 3.2.0