### PR TITLE
Upgrade spring cloud deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -15,7 +15,7 @@ jobs:
       # https://github.com/marketplace/actions/authenticate-to-google-cloud
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
 

--- a/.github/workflows/delete-cluster-gke.yml
+++ b/.github/workflows/delete-cluster-gke.yml
@@ -15,7 +15,7 @@ jobs:
       # https://github.com/marketplace/actions/authenticate-to-google-cloud
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
 

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -26,7 +26,7 @@ jobs:
       # https://github.com/marketplace/actions/authenticate-to-google-cloud
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}
 

--- a/.github/workflows/undeploy-gke.yml
+++ b/.github/workflows/undeploy-gke.yml
@@ -15,7 +15,7 @@ jobs:
       # https://github.com/marketplace/actions/authenticate-to-google-cloud
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GKE_SRVGHA_KEY }}'
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Date | Change
 18.05.2023 | Added screendumps of Microcoffee GUI in doc page.
 23.05.2023 | Upgraded to Spring Boot 3.1.0.
 16.10.2023 | Implemented CSRF protection in the Order API (POST operation).
-26.11.2023 | Upgraded to Spring Boot 3.2.0 and Spring Cloud 2023.0.0.
+09.12.2023 | Upgraded to Spring Boot 3.2.0 and Spring Cloud 2023.0.0.
 
 ## Contents
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:23.0.0
+FROM quay.io/keycloak/keycloak:23.0.1
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.3
+FROM mongo:7.0.4
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,7 +13,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.15</groovy.version>
+        <groovy.version>4.0.16</groovy.version>
         <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -8,17 +8,17 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
-        "@testing-library/jest-dom": "^6.1.3",
-        "@testing-library/react": "^14.0.0",
+        "@testing-library/jest-dom": "^6.1.5",
+        "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.1",
         "bootstrap": "^5.3.2",
         "react": "^18.2.0",
         "react-cookie": "^6.1.1",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.16.0",
+        "react-router-dom": "^6.20.0",
         "react-scripts": "5.0.1",
-        "reactstrap": "^9.2.0",
-        "web-vitals": "^3.4.0"
+        "reactstrap": "^9.2.1",
+        "web-vitals": "^3.5.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
-      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.0.tgz",
+      "integrity": "sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4687,11 +4687,11 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.3.tgz",
-      "integrity": "sha512-YzpjRHoCBWPzpPNtg6gnhasqtE/5O4qz8WCwDEaxtfnPO6gkaLrnuXusrGSPyhIGPezr1HM7ZH0CFaUTY9PJEQ==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.5.tgz",
+      "integrity": "sha512-3y04JLW+EceVPy2Em3VwNr95dOKqA8DhR0RJHhHKDZNYXcVXnEK7WIrpj4eYU8SVt/qYZ2aRWt/WgQ+grNES8g==",
       "dependencies": {
-        "@adobe/css-tools": "^4.3.0",
+        "@adobe/css-tools": "^4.3.1",
         "@babel/runtime": "^7.9.2",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
@@ -4788,9 +4788,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
-      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
+      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",
@@ -17872,11 +17872,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
-      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.0.tgz",
+      "integrity": "sha512-pVvzsSsgUxxtuNfTHC4IxjATs10UaAtvLGVSA1tbUE4GDaOSU1Esu2xF5nWLz7KPiMuW8BJWuPFdlGYJ7/rW0w==",
       "dependencies": {
-        "@remix-run/router": "1.9.0"
+        "@remix-run/router": "1.13.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17886,12 +17886,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0.tgz",
-      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.0.tgz",
+      "integrity": "sha512-CbcKjEyiSVpA6UtCHOIYLUYn/UJfwzp55va4yEfpk7JBN3GPqWfHrdLkAvNCcpXr8QoihcDMuk0dzWZxtlB/mQ==",
       "dependencies": {
-        "@remix-run/router": "1.9.0",
-        "react-router": "6.16.0"
+        "@remix-run/router": "1.13.0",
+        "react-router": "6.20.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -19029,9 +19029,9 @@
       }
     },
     "node_modules/reactstrap": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.0.tgz",
-      "integrity": "sha512-WWLTEG00qYav0E55PorWHReYTkz5IqkVmQNy0h6U81yqjSp9fOLFGV5pYSVeAUz+yRhU/RTE0oAWy22zr6sOIw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.1.tgz",
+      "integrity": "sha512-3d+jo7EEw1GxobrSeTjs+Vq1SNrMnRTcwKp3/t1ufrceTLFHS6LpAck4eLKlzvgQgTpSJpLeJtVQKSqkxbHTiQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -21033,9 +21033,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.4.0.tgz",
-      "integrity": "sha512-n9fZ5/bG1oeDkyxLWyep0eahrNcPDF6bFqoyispt7xkW0xhDzpUBTgyDKqWDi1twT0MgH4HvvqzpUyh0ZxZV4A=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
+      "integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -16242,9 +16242,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16253,10 +16253,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",
     "bootstrap": "^5.3.2",
@@ -12,7 +12,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
-    "reactstrap": "^9.2.0",
+    "reactstrap": "^9.2.1",
     "web-vitals": "^3.4.0"
   },
   "scripts": {

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -4,16 +4,16 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.1.5",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
     "bootstrap": "^5.3.2",
     "react": "^18.2.0",
     "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.16.0",
+    "react-router-dom": "^6.20.0",
     "react-scripts": "5.0.1",
     "reactstrap": "^9.2.1",
-    "web-vitals": "^3.4.0"
+    "web-vitals": "^3.5.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -49,7 +49,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
-        <frontend-maven-plugin.version>1.14.2</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>2.1.1</wro4j-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->
@@ -44,8 +44,8 @@
         <bootstrap.version>5.3.2</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v21.2.0</node.version>
-        <npm.version>10.2.3</npm.version>
+        <node.version>v21.4.0</node.version>
+        <npm.version>10.2.4</npm.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -34,11 +34,11 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.11.0</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
@@ -158,7 +158,7 @@
 
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo.spring31x</artifactId>
+            <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
             <version>${flapdoodle-embed-mongo.version}</version>
             <scope>test</scope>
         </dependency>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -36,10 +36,10 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.11.0</flapdoodle-embed-mongo.version>
-        <spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <modelmapper.version>3.2.0</modelmapper.version>
-        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
@@ -250,7 +250,7 @@
 
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo.spring31x</artifactId>
+            <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
             <version>${flapdoodle-embed-mongo.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
- Updated deps, plugins and GitHub actions from pull requests created by Dependabot.
- Frontend patch update: reactscrap and @testing-library/jest-dom
- Frontend minor update: react-router-dom, web-vitals and @testing-library/react
- Frontend security update: css-tools 4.3.1 -> 4.3.2 (moderate) 
- Updated Spring Cloud 23.0.0-RC1 -> 23.0.0 and Springdoc 2.2.0 -> 2.3.0 + latest Node/NPM releases.
- Changed Embedded Mongo artifact de.flapdoodle.embed.mongo.spring31x -> de.flapdoodle.embed.mongo.spring3x.