### PR TITLE
Java 21 upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
 
-      - name: Setup Java 17
+      - name: Setup Java 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Cache Maven artifacts
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Date | Change
 23.05.2023 | Upgraded to Spring Boot 3.1.0.
 16.10.2023 | Implemented CSRF protection in the Order API (POST operation).
 09.12.2023 | Upgraded to Spring Boot 3.2.0 and Spring Cloud 2023.0.0.
+10.12.2023 | Upgraded to Java 21.
 
 ## Contents
 
@@ -169,7 +170,7 @@ provided.
 ## <a name="prerequisite"></a>Prerequisite
 Microcoffee was originally developed on Windows 10 and tested on Docker running on Oracle VirtualBox. Late 2022, the development environment was modernized and consists now of Windows 11 Pro with Docker Desktop running with WSL2 based engine.
 
-The code was originally written in Java 8, but was later migrated to Java 11. In early 2022, Microcoffee moved on to Java 17.
+The code was originally written in Java 8, but was later migrated to Java 11. In early 2022, Microcoffee moved on to Java 17. Then in december 2023, Microcoffee moved to Java 21.
 
 For building and testing the application on Windows, Docker Desktop with the WSL 2 engine is recommended. See [Install on Docker Desktop on Windows](https://docs.docker.com/desktop/install/windows-install/#install-docker-desktop-on-windows) for installation guidelines.
 
@@ -2017,6 +2018,8 @@ Set-Alias -Name kubectl -Value Start-WslKubectl
 #### Building Microcoffee
 
 ##### Create PowerShell shortcut for Java 17
+
+:point_right: Needs an update to Java 21.
 
 Microcoffee is built on Java 17. If Java 17 is not the default JDK, a PowerShell window can be configured to use Java 17 as follows.
 

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,11 +1,12 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
     && find / -iname "cacerts" \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,10 +1,11 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,10 +1,11 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,10 +1,11 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -109,6 +109,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-proc:full</arg> <!-- Java 21: Enable annotation processing -->
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,10 +1,11 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,11 +1,12 @@
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM amazoncorretto:21.0.1-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE
+ENV JVM_TRUSTSTORE=/usr/lib/jvm/default-jvm/lib/security/cacerts
 COPY target/$JAR_FILE app.jar
 COPY target/keystore/microcoffee-keystore.jks .
 RUN touch app.jar \
-    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore /opt/java/openjdk/lib/security/cacerts -deststorepass changeit \
+    && keytool -importkeystore -noprompt -srckeystore microcoffee-keystore.jks -srcstorepass 12345678 -destkeystore $JVM_TRUSTSTORE -deststorepass changeit \
     && rm microcoffee-keystore.jks
 ENTRYPOINT ["java","-jar","/app.jar"]
 

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -15,13 +15,13 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <surefire.argLine>-Dfile.encoding=UTF-8</surefire.argLine>
-        <failsafe.argLine>-Dfile.encoding=UTF-8</failsafe.argLine>
+        <surefire.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</surefire.argLine>
+        <failsafe.argLine>-Dfile.encoding=UTF-8 -XX:+EnableDynamicAgentLoading</failsafe.argLine>
         <surefire.coverage.argLine/>
         <failsafe.coverage.argLine/>
 
@@ -265,6 +265,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-proc:full</arg> <!-- Java 21: Enable annotation processing -->
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
- Upgrade of Java 17 -> 21.
- Changed Docker image eclipse-temurin:17.0.9_9-jre-alpine -> amazoncorretto:21.0.1-alpine as where is no Temurin image for Java 17 on Docker Hub.
- Added -XX:+EnableDynamicAgentLoading in maven-surefire/failsafe-plugins to fix warning on dynamic loading of Java agent.
- Added -proc:full compiler option in maven-compiler-plugin for some projects to fix warning on annotation processing.
- Changed to Java 21 in GitHub action setup-java. 