### PR TITLE
Spring boot 323 update

### DIFF
--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:23.0.4
+FROM quay.io/keycloak/keycloak:24.0.1
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -13,7 +13,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
         <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -39,7 +39,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -41,7 +41,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -39,7 +39,7 @@
         <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.5
+FROM mongo:7.0.6
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/docker-compose.yml
+++ b/microcoffeeoncloud-database/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     mongodb:
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
-        command: mongod --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --bind_ip_all
+        command: mongod --bind_ip_all --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --setParameter tlsUseSystemCA=true --tlsAllowConnectionsWithoutCertificates
         ports:
             - "27017:27017"
             - "28017:28017"

--- a/microcoffeeoncloud-database/k8s-service-aks.yml
+++ b/microcoffeeoncloud-database/k8s-service-aks.yml
@@ -17,7 +17,7 @@ spec:
       - name: mongodb
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
         imagePullPolicy: Always
-        args: ["--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem", "--bind_ip_all"]
+        args: ["--bind_ip_all", "--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem",  "--setParameter", "tlsUseSystemCA=true", "--tlsAllowConnectionsWithoutCertificates"]
         ports:
         - containerPort: 27017
           hostPort: 27017

--- a/microcoffeeoncloud-database/k8s-service-eks.yml
+++ b/microcoffeeoncloud-database/k8s-service-eks.yml
@@ -17,7 +17,7 @@ spec:
       - name: mongodb
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
         imagePullPolicy: Always
-        args: ["--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem", "--bind_ip_all"]
+        args: ["--bind_ip_all", "--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem",  "--setParameter", "tlsUseSystemCA=true", "--tlsAllowConnectionsWithoutCertificates"]
         ports:
         - containerPort: 27017
           hostPort: 27017

--- a/microcoffeeoncloud-database/k8s-service-gke.yml
+++ b/microcoffeeoncloud-database/k8s-service-gke.yml
@@ -17,7 +17,7 @@ spec:
       - name: mongodb
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
         imagePullPolicy: Always
-        args: ["--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem", "--bind_ip_all"]
+        args: ["--bind_ip_all", "--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem",  "--setParameter", "tlsUseSystemCA=true", "--tlsAllowConnectionsWithoutCertificates"]
         ports:
         - containerPort: 27017
           hostPort: 27017

--- a/microcoffeeoncloud-database/k8s-service-mkube.yml
+++ b/microcoffeeoncloud-database/k8s-service-mkube.yml
@@ -17,7 +17,7 @@ spec:
       - name: mongodb
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
         imagePullPolicy: Always
-        args: ["--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem", "--bind_ip_all"]
+        args: ["--bind_ip_all", "--tlsMode", "preferTLS", "--tlsCertificateKeyFile", "/wildcard.default-key.pem",  "--setParameter", "tlsUseSystemCA=true", "--tlsAllowConnectionsWithoutCertificates"]
         ports:
         - containerPort: 27017
           hostPort: 27017

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,10 +13,10 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.18</groovy.version>
+        <groovy.version>4.0.19</groovy.version>
         <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>3.0.2</gmavenplus-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,7 +13,7 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.19</groovy.version>
+        <groovy.version>4.0.20</groovy.version>
         <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -39,7 +39,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -6881,9 +6881,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001597",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
+      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
       "devOptional": true,
       "funding": [
         {

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -8,16 +8,16 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
-        "@testing-library/jest-dom": "^6.2.0",
+        "@testing-library/jest-dom": "^6.2.1",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.2",
-        "bootstrap": "^5.3.2",
+        "bootstrap": "^5.3.3",
         "react": "^18.2.0",
-        "react-cookie": "^7.0.1",
+        "react-cookie": "^7.0.2",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.2",
-        "reactstrap": "^9.2.1",
-        "web-vitals": "^3.5.1"
+        "react-router-dom": "^6.21.3",
+        "reactstrap": "^9.2.2",
+        "web-vitals": "^3.5.2"
       },
       "devDependencies": {
         "react-scripts": "5.0.1"
@@ -4464,9 +4464,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
-      "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4899,9 +4899,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.2.0.tgz",
-      "integrity": "sha512-+BVQlJ9cmEn5RDMUS8c2+TU6giLvzaHZ8sU/x0Jj7fk+6/46wPdwlgOPcpxS17CjcanBi/3VmGMqVr2rmbUmNw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
       "dependencies": {
         "@adobe/css-tools": "^4.3.2",
         "@babel/runtime": "^7.9.2",
@@ -4919,12 +4919,16 @@
       },
       "peerDependencies": {
         "@jest/globals": ">= 28",
+        "@types/bun": "latest",
         "@types/jest": ">= 28",
         "jest": ">= 28",
         "vitest": ">= 0.32"
       },
       "peerDependenciesMeta": {
         "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
           "optional": true
         },
         "@types/jest": {
@@ -6707,9 +6711,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
-      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -18670,9 +18674,9 @@
       }
     },
     "node_modules/react-cookie": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.0.1.tgz",
-      "integrity": "sha512-SmDjy2TFp+vS6BGOqW7HyaWKyJzVmIH74uP3mxq6kswlwLJEBtIbhkrioozdvQL9r81yprHYFQkSmcO4HiXPdA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.1.0.tgz",
+      "integrity": "sha512-n2+Gt07/xxuShXary+SImk1sw5l7a1UguQOQEN55YewEW5LoA0opbR4nbeo8sY6OYwR37iCFJtqJ0AGEywqAtg==",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.5",
         "hoist-non-react-statics": "^3.3.2",
@@ -18860,11 +18864,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.2.tgz",
-      "integrity": "sha512-jJcgiwDsnaHIeC+IN7atO0XiSRCrOsQAHHbChtJxmgqG2IaYQXSnhqGb5vk2CU/wBQA12Zt+TkbuJjIn65gzbA==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "dependencies": {
-        "@remix-run/router": "1.14.2"
+        "@remix-run/router": "1.15.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -18874,12 +18878,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.2.tgz",
-      "integrity": "sha512-tE13UukgUOh2/sqYr6jPzZTzmzc70aGRP4pAjG2if0IP3aUT+sBtAKUJh0qMh0zylJHGLmzS+XWVaON4UklHeg==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "dependencies": {
-        "@remix-run/router": "1.14.2",
-        "react-router": "6.21.2"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -20087,9 +20091,9 @@
       }
     },
     "node_modules/reactstrap": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.1.tgz",
-      "integrity": "sha512-3d+jo7EEw1GxobrSeTjs+Vq1SNrMnRTcwKp3/t1ufrceTLFHS6LpAck4eLKlzvgQgTpSJpLeJtVQKSqkxbHTiQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.2.tgz",
+      "integrity": "sha512-4KroiGOdqZLAnMGzHjpErW3G7bLB+QbKzzMLIDXydPIV0y74lpdL7WtXHkLWAGInd97WCPNx4+R0NQDPyzIfhw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -22278,9 +22282,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.1.tgz",
-      "integrity": "sha512-xQ9lvIpfLxUj0eSmT79ZjRoU5wIRfIr7pNukL7ZE4EcWZSmfZQqOlhuAGfkVa3EFmzPHZhWhXfm2i5ys+THVPg=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -8,14 +8,14 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
-        "@testing-library/jest-dom": "^6.2.1",
-        "@testing-library/react": "^14.1.2",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.2",
         "bootstrap": "^5.3.3",
         "react": "^18.2.0",
-        "react-cookie": "^7.0.2",
+        "react-cookie": "^7.1.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.3",
+        "react-router-dom": "^6.22.3",
         "reactstrap": "^9.2.2",
         "web-vitals": "^3.5.2"
       },
@@ -5009,9 +5009,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
-      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
+      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^6.2.1",
-    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
     "bootstrap": "^5.3.3",
     "react": "^18.2.0",
-    "react-cookie": "^7.0.2",
+    "react-cookie": "^7.1.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.3",
+    "react-router-dom": "^6.22.3",
     "reactstrap": "^9.2.2",
     "web-vitals": "^3.5.2"
   },

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -3,16 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/jest-dom": "^6.2.1",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
-    "bootstrap": "^5.3.2",
+    "bootstrap": "^5.3.3",
     "react": "^18.2.0",
-    "react-cookie": "^7.0.1",
+    "react-cookie": "^7.0.2",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.2",
-    "reactstrap": "^9.2.1",
-    "web-vitals": "^3.5.1"
+    "react-router-dom": "^6.21.3",
+    "reactstrap": "^9.2.2",
+    "web-vitals": "^3.5.2"
   },
   "devDependencies": {
     "react-scripts": "5.0.1"

--- a/microcoffeeoncloud-gateway/docker-compose.yml
+++ b/microcoffeeoncloud-gateway/docker-compose.yml
@@ -66,7 +66,7 @@ services:
             - discovery
     mongodb:
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
-        command: mongod --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --bind_ip_all
+        command: mongod --bind_ip_all --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --setParameter tlsUseSystemCA=true --tlsAllowConnectionsWithoutCertificates
         ports:
             - "27017:27017"
             - "28017:28017"

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -41,14 +41,14 @@
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->
         <angular-ui-bootstrap.version>2.5.6</angular-ui-bootstrap.version>
-        <bootstrap.version>5.3.2</bootstrap.version>
+        <bootstrap.version>5.3.3</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v21.6.0</node.version>
-        <npm.version>10.2.4</npm.version>
+        <node.version>v21.7.1</node.version>
+        <npm.version>10.5.0</npm.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -51,7 +51,7 @@
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>2.1.1</wro4j-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- Plugin versions -->
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-location/docker-compose.yml
+++ b/microcoffeeoncloud-location/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - discovery
     mongodb:
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
-        command: mongod --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --bind_ip_all
+        command: mongod --bind_ip_all --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --setParameter tlsUseSystemCA=true --tlsAllowConnectionsWithoutCertificates
         ports:
             - "27017:27017"
             - "28017:28017"

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -43,7 +43,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.12.2</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -41,7 +41,7 @@
         <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-order/docker-compose.yml
+++ b/microcoffeeoncloud-order/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - discovery
     mongodb:
         image: dagbjorn/microcoffeeoncloud-database:1.0.0-SNAPSHOT
-        command: mongod --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --bind_ip_all
+        command: mongod --bind_ip_all --tlsMode preferTLS --tlsCertificateKeyFile /microcoffee.study-key.pem --setParameter tlsUseSystemCA=true --tlsAllowConnectionsWithoutCertificates
         ports:
             - "27017:27017"
             - "28017:28017"

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -44,7 +44,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
 
@@ -42,7 +42,7 @@
         <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -39,7 +39,7 @@
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <modelmapper.version>3.2.0</modelmapper.version>
-        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-order/run-local.bat
+++ b/microcoffeeoncloud-order/run-local.bat
@@ -4,7 +4,7 @@ setlocal
 
 set ACTIVE_SPRING_PROFILES=devlocal
 set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
-set ORDER_CLIENT_SECRET=CiQrVgxrjTwheAgtluBVsEDMo0wgIwCC
+set ORDER_CLIENT_SECRET=KNBllvpC9waZ8UaUYxS9NmTHykXVyH8g
 
 mvn spring-boot:run -Dspring-boot.run.profiles=%ACTIVE_SPRING_PROFILES%
 

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -111,7 +111,7 @@ class OrderControllerTest {
             .content(toJson(orderModel)) //
             .contentType(MediaType.APPLICATION_JSON)) //
             .andExpect(status().isPaymentRequired()) //
-            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN));
+            .andReturn();
     }
 
     @Test


### PR DESCRIPTION
- Updated Spring Boot 3.2.2 -> 3.2.3 + latest deps and plugins.
- Updated Docker images keycloak 23.0.4 -> 24.0.1, mongo 7.0.5 -> 7.0.6 and latest eclipse-temurin.
- Update Node v21.6.0 -> v21.7.1 and npm 10.2.4 -> 10.5.0.
- Fixed OrderControllerTest to not expect Content-Type header when no content. (Some change in MockMvc.)
- Fixed issue in MongoDB 7.0.6 which now requires specifying a certificate authority when starting mongod with TLS. Fixed by adding '--setParameter tlsUseSystemCA=true --tlsAllowConnectionsWithoutCertificates' on mongod command line.
- Updated browserslist: node_modules/caniuse-lite 
- Updated frontend patches: bootstrap, react-cookie, react-router-dom, reactstrap, web-vitals, @testing-library/jest-dom
- Updated frontend minor versions: react-cookie 7.1.0, react-router-dom 6.22.3, testing-library/jest-dom 6.4.2, @testing-library/react 14.2.1
- Upgraded Springdoc 2.3.0 -> 2.4.0.
- Updated sonar-maven-plugin 3.10.0.2594 -> 3.11.0.3922.