### PR TITLE
Spring boot 324 update

### DIFF
--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:24.0.1
+FROM quay.io/keycloak/keycloak:24.0.2
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -17,7 +17,7 @@
         <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
         <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -36,11 +36,11 @@
 
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/logging/HttpLoggingFilter.java
+++ b/microcoffeeoncloud-creditrating/src/main/java/study/microcoffee/creditrating/logging/HttpLoggingFilter.java
@@ -6,11 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +19,11 @@ import org.springframework.web.util.WebUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Simple logging filter for HTTP server request and response logging.
@@ -140,7 +140,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedRequest.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedRequest.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedRequest.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -192,7 +193,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedResponse.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedResponse.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedResponse.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -210,6 +212,10 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
     //
     // Common stuff
     //
+
+    private boolean doesContentTypeStartWith(String contentType, String other) {
+        return contentType != null && contentType.startsWith(other);
+    }
 
     private void formatHeaders(StringBuilder builder, HttpHeaders headers) {
         if (!formattedLogging) {

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.6
+FROM mongo:7.0.7
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.7
+FROM mongo:7.0.8
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -6633,13 +6633,13 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -6647,7 +6647,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -7248,10 +7248,9 @@
       "devOptional": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9505,17 +9504,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -18610,9 +18609,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -22064,14 +22063,6 @@
         "cookie": "^0.6.0"
       }
     },
-    "node_modules/universal-cookie/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -22343,9 +22334,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -9812,9 +9812,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^6.4.2",
-        "@testing-library/react": "^14.2.1",
+        "@testing-library/react": "^14.2.2",
         "@testing-library/user-event": "^14.5.2",
         "bootstrap": "^5.3.3",
         "react": "^18.2.0",
@@ -5009,9 +5009,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
-      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.2.tgz",
+      "integrity": "sha512-SOUuM2ysCvjUWBXTNfQ/ztmnKDmqaiPV3SvoIuyxMUca45rbSWWAT/qB8CUs/JQ/ux/8JFs9DNdFQ3f6jH3crA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^14.2.1",
+    "@testing-library/react": "^14.2.2",
     "@testing-library/user-event": "^14.5.2",
     "bootstrap": "^5.3.3",
     "react": "^18.2.0",

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->
@@ -50,7 +50,7 @@
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
         <wro4j-maven-plugin.version>2.1.1</wro4j-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -35,7 +35,7 @@
         <java-jwt.version>4.4.0</java-jwt.version>
 
         <!-- Plugin versions -->
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.12.3</flapdoodle-embed-mongo.version>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -37,7 +37,7 @@
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.12.2</flapdoodle-embed-mongo.version>
+        <flapdoodle-embed-mongo.version>4.12.3</flapdoodle-embed-mongo.version>
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -38,11 +38,11 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.12.2</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/logging/HttpLoggingFilter.java
+++ b/microcoffeeoncloud-location/src/main/java/study/microcoffee/location/logging/HttpLoggingFilter.java
@@ -140,7 +140,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedRequest.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedRequest.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedRequest.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -192,7 +193,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedResponse.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedResponse.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedResponse.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -210,6 +212,10 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
     //
     // Common stuff
     //
+
+    private boolean doesContentTypeStartWith(String contentType, String other) {
+        return contentType != null && contentType.startsWith(other);
+    }
 
     private void formatHeaders(StringBuilder builder, HttpHeaders headers) {
         if (!formattedLogging) {

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -17,5 +17,5 @@ spring.cloud.config.fail-fast=false
 # Disable Eureka client
 eureka.client.enabled=false
 
-# Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/download-center/community/releases)
-de.flapdoodle.mongodb.embedded.version=7.0.4
+# Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
+de.flapdoodle.mongodb.embedded.version=7.0.7

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -35,7 +35,7 @@
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.12.2</flapdoodle-embed-mongo.version>
+        <flapdoodle-embed-mongo.version>4.12.3</flapdoodle-embed-mongo.version>
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <modelmapper.version>3.2.0</modelmapper.version>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -39,11 +39,11 @@
         <spring-cloud.version>2023.0.0</spring-cloud.version>
 
         <modelmapper.version>3.2.0</modelmapper.version>
-        <springdoc-openapi.version>2.4.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
     </properties>
 

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.12.3</flapdoodle-embed-mongo.version>
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
 
         <modelmapper.version>3.2.0</modelmapper.version>
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/common/logging/HttpLoggingFilter.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/common/logging/HttpLoggingFilter.java
@@ -140,7 +140,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedRequest.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedRequest.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedRequest.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -192,7 +193,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             try {
                 payload = new String(buf, 0, buf.length, wrappedResponse.getCharacterEncoding());
 
-                if (isFormattedLogging() && wrappedResponse.getContentType().startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+                if (isFormattedLogging()
+                    && doesContentTypeStartWith(wrappedResponse.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
                     Object object = objectMapper.readValue(payload, Object.class);
                     payload = lineTerminator + objectMapper.writeValueAsString(object);
                 }
@@ -210,6 +212,10 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
     //
     // Common stuff
     //
+
+    private boolean doesContentTypeStartWith(String contentType, String other) {
+        return contentType != null && contentType.startsWith(other);
+    }
 
     private void formatHeaders(StringBuilder builder, HttpHeaders headers) {
         if (!formattedLogging) {

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -39,5 +39,5 @@ spring.security.oauth2.client.registration.order-service.client-id=order-service
 spring.security.oauth2.client.registration.order-service.client-secret=123-abc-456-xyz
 spring.security.oauth2.client.registration.order-service.authorization-grant-type=client_credentials
 
-# Define the version of Embedded Mongo autoconfigured by Spring Boot (artifact: de.flapdoodle.embed.mongo).
-de.flapdoodle.mongodb.embedded.version=7.0.4
+# Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
+de.flapdoodle.mongodb.embedded.version=7.0.7


### PR DESCRIPTION
- Updated Spring Boot 3.2.3 -> 3.2.4 and keyclock 24.0.1 -> 24.0.2 + plugins.
- Updated Spring Cloud 2023.0.0 -> 2023.0.1. 
- Upgraded Springdoc 2.4.0 -> 2.5.0 and jacoco-maven-plugin 0.8.11 -> 0.8.12.
- Updated Docker image mongo 7.0.6 -> 7.0.8 abd flapdoodle-embed-mongo 4.12.2 -> 4.12.3.
- Fixed Sonar issue: A NullPointerException could be thrown; getContentType() can return null.
- Fixed frontend security issues with 'npm audit fix': follow-redirects 1.15.5 -> 1.15.6, webpack-dev-middleware 5.3.3 -> 5.3.4
- Updated frontend patches: testing-library/react 14.2.2