### PR TITLE
Gatling java21 upgrade

### DIFF
--- a/microcoffeeoncloud-gatlingtest/pom.xml
+++ b/microcoffeeoncloud-gatlingtest/pom.xml
@@ -11,15 +11,15 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 
-		<gatling.version>3.8.4</gatling.version>
-		<json4s-jackson.version>4.0.6</json4s-jackson.version>
+		<gatling.version>3.11.3</gatling.version>
+		<json4s-jackson.version>4.0.7</json4s-jackson.version>
 
-		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-		<gatling-maven-plugin.version>4.2.7</gatling-maven-plugin.version>
-		<scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>
+		<build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+		<gatling-maven-plugin.version>4.9.1</gatling-maven-plugin.version>
+		<scala-maven-plugin.version>4.9.1</scala-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -91,7 +91,7 @@
 								<jvmArg>-Xss100M</jvmArg>
 							</jvmArgs>
 							<args>
-								<arg>-target:jvm-17</arg>
+								<arg>-release:${maven.compiler.target}</arg>
 								<arg>-deprecation</arg>
 								<arg>-feature</arg>
 								<arg>-unchecked</arg>

--- a/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/OrderApiTest.scala
+++ b/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/OrderApiTest.scala
@@ -36,9 +36,16 @@ class OrderApiTest extends Simulation {
   private val scn = scenario("Order API")
     .feed(orderFeeder)
 
+    .exec(http("Get CSRF token")
+      .get("/api/coffeeshop/#{coffeeShopId}/order/9999999999")
+      .check(status.is(204))
+      .check(header("X-XSRF-TOKEN").exists.saveAs("csrfToken")))
+
     .exec(http("Submit order")
       .post("/api/coffeeshop/#{coffeeShopId}/order")
       .header("Content-Type", "application/json")
+      .header("Cookie", "XSRF-TOKEN=#{csrfToken}")
+      .header("X-XSRF-TOKEN", "#{csrfToken}")
       .body(ElFileBody("OrderTemplate.json")).asJson
       .check(status.is(201))
       .check(header("Location").exists.saveAs("location")))

--- a/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/OrderApiTest.scala
+++ b/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/OrderApiTest.scala
@@ -38,7 +38,7 @@ class OrderApiTest extends Simulation {
 
     .exec(http("Get CSRF token")
       .get("/api/coffeeshop/#{coffeeShopId}/order/9999999999")
-      .check(status.is(204))
+      .check(status.in(200, 204))
       .check(header("X-XSRF-TOKEN").exists.saveAs("csrfToken")))
 
     .exec(http("Submit order")


### PR DESCRIPTION
- Upgraded Java 17 -> 21, Gatling 3.8.4 -> 3.11.3, gatling-maven-plugin 4.2.7 -> 4.9.1, scala-maven-plugin 4.7.2 -> 4.9.1 + other deps and plugins.
- Fixed missing X-XSRF-TOKEN in call to Order API.