### PR TITLE
Springboot 333 update

### DIFF
--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create cluster
         run: |-
-          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=n1-standard-1 --num-nodes=4 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
+          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=n1-standard-2 --num-nodes=4 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
           gcloud compute instances list
 
       - name: Create firewall rules

--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create cluster
         run: |-
-          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=n1-standard-2 --num-nodes=4 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
+          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=e2-small --num-nodes=4 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
           gcloud compute instances list
 
       - name: Create firewall rules

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -53,7 +53,8 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app=authserver --timeout=300s
 
           # Since we have disabled the probes of Keycloak because of unknown issue we need to sleep instead
-          sleep 30
+          echo "Sleep for 45 seconds..."
+          sleep 45
 
       - name: Regenerate Keycloak secret of order-service client and create Kubernetes secret
         run: |-

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -40,6 +40,8 @@ jobs:
         run: |-
           gcloud info
 
+          curl --version
+
       # https://github.com/marketplace/actions/get-gke-credentials
       - name: Get GKE credentials and setup a kubeconfig file
         uses: google-github-actions/get-gke-credentials@v2

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -61,7 +61,7 @@ jobs:
           echo "EXTERNAL_IP=$EXTERNAL_IP"
 
           # Get an admin token (using retry since we have disabled the probes of Keycloak because of an unknown issue)
-          ADMINTOKEN=$(curl -s -k --retry-all-errors --retry 4 --retry-delay 0 -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
+          ADMINTOKEN=$(curl -s -k --retry-connrefused --retry 4 --retry-delay 0 -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
 
           # Get id of order-service client
           ID=$(curl -s -k -H "Authorization: Bearer $ADMINTOKEN" https://$EXTERNAL_IP:30456/admin/realms/microcoffee/clients | jq -r ".[] | select(.clientId == \"order-service\") | .id")

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -52,6 +52,9 @@ jobs:
           kubectl apply -f microcoffeeoncloud-authserver/k8s-service-gke.yml
           kubectl wait --for=condition=Ready pod -l app=authserver --timeout=300s
 
+          # Since we have disabled the probes of Keycloak because of unknown issue we need to sleep instead
+          sleep 30
+
       - name: Regenerate Keycloak secret of order-service client and create Kubernetes secret
         run: |-
           # Get EXTERNAL_IP of one of the cluster nodes

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -52,18 +52,14 @@ jobs:
           kubectl apply -f microcoffeeoncloud-authserver/k8s-service-gke.yml
           kubectl wait --for=condition=Ready pod -l app=authserver --timeout=300s
 
-          # Since we have disabled the probes of Keycloak because of unknown issue we need to sleep instead
-          echo "Sleep for 45 seconds..."
-          sleep 45
-
       - name: Regenerate Keycloak secret of order-service client and create Kubernetes secret
         run: |-
           # Get EXTERNAL_IP of one of the cluster nodes
           EXTERNAL_IP=$(gcloud compute instances list --project $GKE_PROJECT --format json | jq -r ".[0].networkInterfaces[0].accessConfigs[0].natIP")
           echo "EXTERNAL_IP=$EXTERNAL_IP"
 
-          # Get an admin token
-          ADMINTOKEN=$(curl -s -k -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
+          # Get an admin token (using retry since we have disabled the probes of Keycloak because of an unknown issue)
+          ADMINTOKEN=$(curl -s -k --retry-all-errors --retry 4 --retry-delay 0 -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
 
           # Get id of order-service client
           ID=$(curl -s -k -H "Authorization: Bearer $ADMINTOKEN" https://$EXTERNAL_IP:30456/admin/realms/microcoffee/clients | jq -r ".[] | select(.clientId == \"order-service\") | .id")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Date | Change
 09.12.2023 | Upgraded to Spring Boot 3.2.0 and Spring Cloud 2023.0.0.
 10.12.2023 | Upgraded to Java 21.
 03.01.2024 | Added roles/servicedirectory.editor in Setup for GitHub Actions workflows.
-02.06.2024 1 Upgraded to Spring Boot 3.3.0.
+02.06.2024 | Upgraded to Spring Boot 3.3.0.
 
 ## Contents
 

--- a/microcoffeeoncloud-authserver/k8s-service-aks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-aks.yml
@@ -18,21 +18,22 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true"]
-        readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /health/live
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
+        # Disable probes because for some unkwown reason they have stopped working
+        readinessProbe: null
+#          httpGet:
+#            path: /health/ready
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
+        livenessProbe: null
+#          httpGet:
+#            path: /health/live
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456

--- a/microcoffeeoncloud-authserver/k8s-service-eks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-eks.yml
@@ -18,21 +18,22 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true"]
-        readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /health/live
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
+        # Disable probes because for some unkwown reason they have stopped working
+        readinessProbe: null
+#          httpGet:
+#            path: /health/ready
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
+        livenessProbe: null
+#          httpGet:
+#            path: /health/live
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456

--- a/microcoffeeoncloud-authserver/k8s-service-gke.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-gke.yml
@@ -18,21 +18,22 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true"]
-        readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /health/live
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
+        # Disable probes because for some unkwown reason they have stopped working
+        readinessProbe: null
+#          httpGet:
+#            path: /health/ready
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
+        livenessProbe: null
+#          httpGet:
+#            path: /health/live
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456

--- a/microcoffeeoncloud-authserver/k8s-service-mkube.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-mkube.yml
@@ -18,21 +18,22 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true"]
-        readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /health/live
-            port: 8093
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
+        # Disable probes because for some unkwown reason they have stopped working
+        readinessProbe: null
+#          httpGet:
+#            path: /health/ready
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
+        livenessProbe: null
+#          httpGet:
+#            path: /health/live
+#            port: 8093
+#          initialDelaySeconds: 60
+#          periodSeconds: 10
+#          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -13,10 +13,10 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-dependency-plugin.version>3.7.0</maven-dependency-plugin.version>
-        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>

--- a/microcoffeeoncloud-authserver/pom.xml
+++ b/microcoffeeoncloud-authserver/pom.xml
@@ -15,7 +15,7 @@
 
         <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -14,14 +14,14 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
         <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
 
         <!-- VM host IP -->
         <vmHostIp>192.168.99.100</vmHostIp>

--- a/microcoffeeoncloud-configserver/Dockerfile
+++ b/microcoffeeoncloud-configserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -34,10 +34,10 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-creditrating/Dockerfile
+++ b/microcoffeeoncloud-creditrating/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,12 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.12
+FROM mongo:7.0.14
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/Dockerfile
+++ b/microcoffeeoncloud-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:7.0.11
+FROM mongo:7.0.12
 WORKDIR /
 COPY target/keystore/*.p12 ./
 RUN openssl version \

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -19,7 +19,7 @@
         <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>3.0.2</gmavenplus-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -13,14 +13,14 @@
 
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <groovy.version>4.0.21</groovy.version>
+        <groovy.version>4.0.22</groovy.version>
         <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <gmavenplus-plugin.version>3.0.2</gmavenplus-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-dependency-plugin.version>3.7.0</maven-dependency-plugin.version>
-        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
 
         <docker.image.prefix>dagbjorn</docker.image.prefix>
     </properties>

--- a/microcoffeeoncloud-discovery/Dockerfile
+++ b/microcoffeeoncloud-discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -34,10 +34,10 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-gateway/Dockerfile
+++ b/microcoffeeoncloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->
@@ -44,11 +44,11 @@
         <bootstrap.version>5.3.3</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v22.2.0</node.version>
-        <npm.version>10.7.0</npm.version>
+        <node.version>v22.6.0</node.version>
+        <npm.version>10.8.1</npm.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/Dockerfile
+++ b/microcoffeeoncloud-location/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -34,14 +34,14 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.14.0</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <flapdoodle-embed-mongo.version>4.16.1</flapdoodle-embed-mongo.version>
+        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
-de.flapdoodle.mongodb.embedded.version=7.0.11
+de.flapdoodle.mongodb.embedded.version=7.0.12

--- a/microcoffeeoncloud-order/Dockerfile
+++ b/microcoffeeoncloud-order/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.3_9-jre-alpine
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 VOLUME /tmp
 WORKDIR /
 ARG JAR_FILE

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/>
     </parent>
 
@@ -35,14 +35,14 @@
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.14.0</flapdoodle-embed-mongo.version>
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
+        <flapdoodle-embed-mongo.version>4.16.1</flapdoodle-embed-mongo.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
 
-        <modelmapper.version>3.2.0</modelmapper.version>
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <modelmapper.version>3.2.1</modelmapper.version>
+        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     </properties>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -40,4 +40,4 @@ spring.security.oauth2.client.registration.order-service.client-secret=123-abc-4
 spring.security.oauth2.client.registration.order-service.authorization-grant-type=client_credentials
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
-de.flapdoodle.mongodb.embedded.version=7.0.11
+de.flapdoodle.mongodb.embedded.version=7.0.12

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Updated Spring Boot 3.3.1 -> 3.3.3, Spring Cloud 2024.0.2 -> 2024.0.3, SpringDoc 2.5.0 -> 2.6.0, MongoDB 7.0.11 -> 7.0.14 and latest versions of other deps and plugins.
- Changed machine type from n1-standard-1 to e2-small because of often unavailable n1-standard-1 nodes.
- Disabled readiness and liveness probes of Keycloak because they don't work (connection refused). Also, deploy workflow gets connection refused from Keycloak when trying to get an admin token. curl with retry didn't help.