### PR TITLE
Keycloack 25 readiness probe fix

### DIFF
--- a/.github/workflows/create-cluster-gke.yml
+++ b/.github/workflows/create-cluster-gke.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create cluster
         run: |-
-          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=e2-small --num-nodes=4 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
+          gcloud container clusters create ${{ env.GKE_CLUSTER }} --machine-type=e2-small --num-nodes=5 --disk-size=10GB --zone=${{ env.GKE_ZONE }}
           gcloud compute instances list
 
       - name: Create firewall rules

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -60,8 +60,8 @@ jobs:
           EXTERNAL_IP=$(gcloud compute instances list --project $GKE_PROJECT --format json | jq -r ".[0].networkInterfaces[0].accessConfigs[0].natIP")
           echo "EXTERNAL_IP=$EXTERNAL_IP"
 
-          # Get an admin token (using retry since we have disabled the probes of Keycloak because of an unknown issue)
-          ADMINTOKEN=$(curl -s -k --retry-connrefused --retry 4 --retry-delay 0 -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
+          # Get an admin token
+          ADMINTOKEN=$(curl -s -k -d "client_id=admin-cli" -d "username=${{secrets.KEYCLOAK_ADMIN_USER}}" -d "password=${{secrets.KEYCLOAK_ADMIN_PASSWORD}}" -d "grant_type=password" https://$EXTERNAL_IP:30456/realms/master/protocol/openid-connect/token | jq -r ".access_token")
 
           # Get id of order-service client
           ID=$(curl -s -k -H "Authorization: Bearer $ADMINTOKEN" https://$EXTERNAL_IP:30456/admin/realms/microcoffee/clients | jq -r ".[] | select(.clientId == \"order-service\") | .id")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Date | Change
 10.12.2023 | Upgraded to Java 21.
 03.01.2024 | Added roles/servicedirectory.editor in Setup for GitHub Actions workflows.
 02.06.2024 | Upgraded to Spring Boot 3.3.0.
+03.09.2024 | Added port 8457/30457 used by Keycloak management interface for Kubernetes readiness/liveness probes.
 
 ## Contents
 
@@ -919,16 +920,16 @@ As usual, run `gcloud compute disks list` to get an EXTERNAL_IP of one of the cr
 
 #### Summary of external port numbers
 
-Microservice | http port | https port
------------- | --------- | ----------
-gateway | - | 30443
-location | 30081 | 30444
-order | 30082 | 30445
-creditrating | 30083 | 30446
-configserver | 30091 | 30454
-discovery | 30092 | 30455
-authserver | 30093 | 30456
-database | 30017 | 30017
+Microservice | http port | https port | https mgmt port
+------------ | --------- | ---------- | ---------------
+gateway | - | 30443 |
+location | 30081 | 30444 |
+order | 30082 | 30445 |
+creditrating | 30083 | 30446 |
+configserver | 30091 | 30454 |
+discovery | 30092 | 30455 |
+authserver | 30093 | 30456 | 30457
+database | 30017 | 30017 |
 
 ### <a name="microcoffee-on-eks"></a>Microcoffee on Amazon Elastic Kubernetes Service (EKS)
 
@@ -1189,16 +1190,16 @@ In addition to the managed policies above, create the following inline policy to
 
 #### Summary of external port numbers
 
-Microservice | http port | https port | Comment
------------- | --------- | ---------- | -------
-gateway | - | 443/30443 | Load balancer: 443, Node port: 30443
-location | 30081 | 30444 |
-order | 30082 | 30445 |
-creditrating | 30083 | 30446 |
-configserver | 30091 | 30454 |
-discovery | 30092 | 30455 |
-authserver | 30093 | 30456 |
-database | 30017 | 30017 |
+Microservice | http port | https port | https mgmt port | Note
+------------ | --------- | ---------- | --------------- | ----
+gateway | - | 443/30443 | | Load balancer: 443, Node port: 30443
+location | 30081 | 30444 | |
+order | 30082 | 30445 | |
+creditrating | 30083 | 30446 | |
+configserver | 30091 | 30454 | |
+discovery | 30092 | 30455 | |
+authserver | 30093 | 30456 | 30457
+database | 30017 | 30017 | |
 
 #### Overview of AWS dashboards
 
@@ -1410,16 +1411,16 @@ Verify that both the resource group and the node resource group of Microcoffee a
 
 #### Summary of external port numbers
 
-Microservice | http port | https port | Comment
------------- | --------- | ---------- | -------
-gateway | - | 8443 |
-location | 8081 | 8444 |
-order | 8082 | 8445 |
-creditrating | 8083 | 8446 |
-configserver | 8091 | 8454 |
-discovery | 8092 | 8455 | NodePort => No external IP.
-authserver | 8093 | 8456 |
-database | 27017 | 27017 |
+Microservice | http port | https port | https mgmt port | Note
+------------ | --------- | ---------- | --------------- | ----
+gateway | - | 8443 | |
+location | 8081 | 8444 | |
+order | 8082 | 8445 | |
+creditrating | 8083 | 8446 | |
+configserver | 8091 | 8454 | |
+discovery | 8092 | 8455 | | NodePort => No external IP.
+authserver | 8093 | 8456 | 8457
+database | 27017 | 27017 | |
 
 Only LoadBalancer services are externally available.
 
@@ -1542,16 +1543,16 @@ As usual, run `gsudo minikube ip` to get the NODE_IP of the Minikube cluster.
 
 #### Summary of port numbers
 
-Microservice | http port | https port
------------- | --------- | ----------
-gateway | - | 30443
-location | 30081 | 30444
-order | 30082 | 30445
-creditrating | 30083 | 30446
-configserver | 30091 | 30454
-discovery | 30092 | 30455
-authserver | 30093 | 30456
-database | 27017 | 27017
+Microservice | http port | https port | https mgmt port
+------------ | --------- | ---------- | ---------------
+gateway | - | 30443 |
+location | 30081 | 30444 |
+order | 30082 | 30445 |
+creditrating | 30083 | 30446 |
+configserver | 30091 | 30454 |
+discovery | 30092 | 30455 |
+authserver | 30093 | 30456 30457
+database | 27017 | 27017 |
 
 ### <a name="api-load-testing-gatling"></a>API load testing with Gatling
 

--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,7 @@ order | 30082 | 30445 |
 creditrating | 30083 | 30446 |
 configserver | 30091 | 30454 |
 discovery | 30092 | 30455 |
-authserver | 30093 | 30456 30457
+authserver | 30093 | 30456 | 30457
 database | 27017 | 27017 |
 
 ### <a name="api-load-testing-gatling"></a>API load testing with Gatling
@@ -2093,7 +2093,7 @@ To run Microcoffee, see the main documentation above. To test Microcoffee, open 
 
 When starting Minikube with the docker driver (will be auto-detected by default), we need to expose all ports used by Microcoffee by specifying a number of `--ports` flags on command-line as follows.
 
-    minikube start --ports=27017:27017 --ports=30080:30080 --ports=30081:30081 --ports=30082:30082 --ports=30083:30083 --ports=30091:30091 --ports=30092:30092 --ports=30093:30093 --ports=30443:30443 --ports=30444:30444 --ports=30445:30445 --ports=30446:30446 --ports=30454:30454 --ports=30455:30455 --ports=30456:30456
+    minikube start --ports=27017:27017 --ports=30080:30080 --ports=30081:30081 --ports=30082:30082 --ports=30083:30083 --ports=30091:30091 --ports=30092:30092 --ports=30093:30093 --ports=30443:30443 --ports=30444:30444 --ports=30445:30445 --ports=30446:30446 --ports=30454:30454 --ports=30455:30455 --ports=30456:30456 --ports=30457:30457
 
 :warning: Port mappings cannot be changed once the Minikube cluster is created. Any `--ports` flags specified are ignored when starting an existing cluster. To change the port mappings, delete the cluster first by running `minikube delete`.
 

--- a/README.md
+++ b/README.md
@@ -262,16 +262,16 @@ Configuration is served by the configuration server. The URL of the configuratio
 
 The port numbers are:
 
-Microservice | http port | https port | Note
------------- | --------- | ---------- | ----------
-gateway | - | 8443 | gateway is based on Spring Cloud Gateway running Netty under the hood. Netty only supports a single port in one and the same application, hence gateway has no port to spare for http.
-location | 8081 | 8444 |
-order | 8082 | 8445 |
-creditrating | 8083 | 8446 |
-configserver | 8091 | 8454 |
-discovery | 8092 | 8455 |
-authserver | 8092 | 8456 |
-database | 27017 | 27017 |
+Microservice | http port | https port | https mgmt port | Note
+------------ | --------- | ---------- | --------------- | ----
+gateway | - | 8443 | | gateway is based on Spring Cloud Gateway running Netty under the hood. Netty only supports a single port in one and the same application, hence gateway has no port to spare for http.
+location | 8081 | 8444 | |
+order | 8082 | 8445 | |
+creditrating | 8083 | 8446 | |
+configserver | 8091 | 8454 | |
+discovery | 8092 | 8455 | |
+authserver | 8092 | 8456 | 8457 |
+database | 27017 | 27017 | |
 
 ## <a name="setting-up-database"></a>Setting up the database
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:25.0.1
+FROM quay.io/keycloak/keycloak:25.0.4
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-authserver/docker-compose.yml
+++ b/microcoffeeoncloud-authserver/docker-compose.yml
@@ -4,11 +4,17 @@ services:
         ports:
           - "8093:8093"
           - "8456:8456"
+          - "8457:8457"
         environment:
           - KEYCLOAK_ADMIN=admin
           - KEYCLOAK_ADMIN_PASSWORD=admin
         domainname: microcoffee.study
-        entrypoint: ["/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/microcoffee.study.p12", "--https-key-store-password=12345678", "--health-enabled=true"]
+        entrypoint: ["/opt/keycloak/bin/kc.sh", "start-dev",
+                     "--import-realm",
+                     "--http-enabled=true", "--http-port=8093",
+                     "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/microcoffee.study.p12", "--https-key-store-password=12345678",
+                     "--http-management-port=8457",
+                     "--health-enabled=true", "--metrics-enabled=true"]
         networks:
             authserver:
                 aliases:

--- a/microcoffeeoncloud-authserver/k8s-service-aks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-aks.yml
@@ -18,25 +18,32 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
-        # Disable probes because for some unkwown reason they have stopped working
-        readinessProbe: null
-#          httpGet:
-#            path: /health/ready
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
-        livenessProbe: null
-#          httpGet:
-#            path: /health/live
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
+        args: ["start-dev",
+               "--import-realm",
+               "--http-enabled=true", "--http-port=8093",
+               "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678",
+               "--http-management-port=8457",
+               "--health-enabled=true", "--metrics-enabled=true"]
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456
+        - containerPort: 8457
         env:
         - name: KEYCLOAK_ADMIN
           value: "admin"
@@ -58,5 +65,9 @@ spec:
     - port: 8456
       targetPort: 8456
       name: auth-https
+    - port: 8457
+      targetPort: 8457
+      nodePort: 30457
+      name: auth-https-mgmt
   selector:
     app: authserver

--- a/microcoffeeoncloud-authserver/k8s-service-eks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-eks.yml
@@ -18,25 +18,32 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
-        # Disable probes because for some unkwown reason they have stopped working
-        readinessProbe: null
-#          httpGet:
-#            path: /health/ready
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
-        livenessProbe: null
-#          httpGet:
-#            path: /health/live
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
+        args: ["start-dev",
+               "--import-realm",
+               "--http-enabled=true", "--http-port=8093",
+               "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678",
+               "--http-management-port=8457",
+               "--health-enabled=true", "--metrics-enabled=true"]
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456
+        - containerPort: 8457
         env:
         - name: KEYCLOAK_ADMIN
           value: "admin"
@@ -60,5 +67,9 @@ spec:
       targetPort: 8456
       nodePort: 30456
       name: auth-https
+    - port: 8457
+      targetPort: 8457
+      nodePort: 30457
+      name: auth-https-mgmt
   selector:
     app: authserver

--- a/microcoffeeoncloud-authserver/k8s-service-gke.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-gke.yml
@@ -18,25 +18,32 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
-        # Disable probes because for some unkwown reason they have stopped working
-        readinessProbe: null
-#          httpGet:
-#            path: /health/ready
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
-        livenessProbe: null
-#          httpGet:
-#            path: /health/live
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
+        args: ["start-dev",
+               "--import-realm",
+               "--http-enabled=true", "--http-port=8093",
+               "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678",
+               "--http-management-port=8457",
+               "--health-enabled=true", "--metrics-enabled=true"]
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456
+        - containerPort: 8457
         env:
         - name: KEYCLOAK_ADMIN
           value: "admin"
@@ -60,5 +67,9 @@ spec:
       targetPort: 8456
       nodePort: 30456
       name: auth-https
+    - port: 8457
+      targetPort: 8457
+      nodePort: 30457
+      name: auth-https-mgmt
   selector:
     app: authserver

--- a/microcoffeeoncloud-authserver/k8s-service-mkube.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-mkube.yml
@@ -18,25 +18,32 @@ spec:
         image: dagbjorn/microcoffeeoncloud-authserver:1.0.0-SNAPSHOT
         imagePullPolicy: Always
         command: ["/opt/keycloak/bin/kc.sh"]
-        args: ["start-dev", "--import-realm", "--http-enabled=true", "--http-port=8093", "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678", "--health-enabled=true", "--metrics-enabled=true"]
-        # Disable probes because for some unkwown reason they have stopped working
-        readinessProbe: null
-#          httpGet:
-#            path: /health/ready
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
-        livenessProbe: null
-#          httpGet:
-#            path: /health/live
-#            port: 8093
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          timeoutSeconds: 5
+        args: ["start-dev",
+               "--import-realm",
+               "--http-enabled=true", "--http-port=8093",
+               "--https-port=8456", "--https-key-store-file=/opt/microcoffee/keystore/wildcard.default.p12", "--https-key-store-password=12345678",
+               "--http-management-port=8457",
+               "--health-enabled=true", "--metrics-enabled=true"]
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8457
+            scheme: HTTPS
+          initialDelaySeconds: 90
+          periodSeconds: 10
+          timeoutSeconds: 5
         ports:
         - containerPort: 8093
         - containerPort: 8456
+        - containerPort: 8457
         env:
         - name: KEYCLOAK_ADMIN
           value: "admin"
@@ -60,5 +67,9 @@ spec:
       targetPort: 8456
       nodePort: 30456
       name: auth-https
+    - port: 8457
+      targetPort: 8457
+      nodePort: 30457
+      name: auth-https-mgmt
   selector:
     app: authserver

--- a/microcoffeeoncloud-authserver/run-local.bat
+++ b/microcoffeeoncloud-authserver/run-local.bat
@@ -2,7 +2,7 @@
 
 setlocal
 
-set KEYCLOAK_HOME=D:\bin\keycloak-23.0.3
+set KEYCLOAK_HOME=D:\bin\keycloak-25.0.4
 
 set KEYCLOAK_ADMIN=admin
 set KEYCLOAK_ADMIN_PASSWORD=admin
@@ -13,6 +13,10 @@ md %KEYCLOAK_HOME%\data\import\
 copy src\main\keycloak\microcoffee-realm.json %KEYCLOAK_HOME%\data\import\.
 
 cd /d %KEYCLOAK_HOME%
-bin\kc.bat start-dev --import-realm --http-enabled=true --http-port=8093 --https-port=8456 --https-key-store-file=localhost.p12 --https-key-store-password=12345678 --health-enabled=true
+bin\kc.bat start-dev --import-realm ^
+                     --http-enabled=true --http-port=8093 ^
+                     --https-port=8456 --https-key-store-file=localhost.p12 --https-key-store-password=12345678 ^
+                     --http-management-port=8457 ^
+                     --health-enabled=true --metrics-enabled=true
 
 endlocal


### PR DESCRIPTION
- Fixed readiness/liveness probes which must run on a new management interface in Keycloak 25. Port 8457 is configured and only HTTPS is supported.
- Reverted curl retries in deployment workflow.
- Updated Keycloak 25.0.1 -> 25.0.4.
- Increased number of e2-small nodes from 4 to 5.
- Updated doc with new management port in Keycloak 25.