### PR TITLE
Gatling 3.13.1 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,7 +1611,9 @@ Run > Edit Configurations... > + (Add New Configuration) > Application
 * Name: OrderApiTest
 * Main class: study.microcoffee.scenario.OrderApiTestRunner
 * Modify options > Add VM options
-    * VM options: -Dapp.baseUrl=https\://localhost:8443 -Dtest.numberOfUsers=1 -Dtest.durationMinutes=0 -Dtest.durationSeconds=10
+  - VM options: `--add-opens=java.base/java.lang=ALL-UNNAMED -Dapp.baseUrl=https\://localhost:8443 -Dtest.numberOfUsers=1 -Dtest.durationMinutes=0 -Dtest.durationSeconds=10`
+
+:point_right: The VM option `--add-opens=java.base/java.lang=ALL-UNNAMED` is required starting from Gatling 3.13.
 
 #### Test report
 

--- a/microcoffeeoncloud-gatlingtest/pom.xml
+++ b/microcoffeeoncloud-gatlingtest/pom.xml
@@ -14,12 +14,12 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 
-		<gatling.version>3.11.3</gatling.version>
+		<gatling.version>3.13.1</gatling.version>
 		<json4s-jackson.version>4.0.7</json4s-jackson.version>
 
 		<build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-		<gatling-maven-plugin.version>4.9.1</gatling-maven-plugin.version>
-		<scala-maven-plugin.version>4.9.1</scala-maven-plugin.version>
+		<gatling-maven-plugin.version>4.10.2</gatling-maven-plugin.version>
+		<scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
 	</properties>
 
 	<dependencies>

--- a/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/LocationApiTest.scala
+++ b/microcoffeeoncloud-gatlingtest/src/test/scala/study/microcoffee/scenario/LocationApiTest.scala
@@ -9,7 +9,6 @@ class LocationApiTest extends Simulation {
 
   private val baseUrl: String = readProperty("app.baseUrl")
   private val numberOfUsers: Int = readProperty("test.numberOfUsers", "1").toInt
-  private val durationMinutes: Int = readProperty("test.durationMinutes", "1").toInt
   private val durationSeconds: Int = readDurationAsSeconds("test.durationMinutes", "test.durationSeconds", "1")
 
   println(s"baseUrl: $baseUrl")


### PR DESCRIPTION
- Upgraded Gatling 3.11.3 -> 3.13.1 and plugins to newest versions. Gatling 3.13.1 required VM option --add-opens=java.base/java.lang=ALL-UNNAMED.