### PR TITLE
Springboot 340 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Date | Change
 03.01.2024 | Added roles/servicedirectory.editor in Setup for GitHub Actions workflows.
 02.06.2024 | Upgraded to Spring Boot 3.3.0.
 03.09.2024 | Added port 8457/30457 used by Keycloak management interface for Kubernetes readiness/liveness probes.
+03.12.2024 | Upgraded to Spring Boot 3.4.0 and Spring Cloud 2024.0.0.
 
 ## Contents
 

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.0.6
+FROM quay.io/keycloak/keycloak:26.0.7
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.0.5
+FROM quay.io/keycloak/keycloak:26.0.6
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-certificates/pom.xml
+++ b/microcoffeeoncloud-certificates/pom.xml
@@ -21,7 +21,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
 
         <!-- VM host IP -->
         <vmHostIp>192.168.99.100</vmHostIp>

--- a/microcoffeeoncloud-configserver/pom.xml
+++ b/microcoffeeoncloud-configserver/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-discovery/pom.xml
+++ b/microcoffeeoncloud-discovery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^18.3.1",
         "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.27.0",
+        "react-router-dom": "^7.0.2",
         "reactstrap": "^9.2.3",
         "web-vitals": "^4.2.4"
       },
@@ -2867,14 +2867,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
-      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -5678,9 +5670,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -13675,33 +13667,49 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
-      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
       "dependencies": {
-        "@remix-run/router": "1.20.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
-      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.2.tgz",
+      "integrity": "sha512-VJOQ+CDWFDGaWdrG12Nl+d7yHtLaurNgAQZVgaIy7/Xd+DojgmYLosFfZdGz1wpxmjJIAkAMVTKWcvkx1oggAw==",
       "dependencies": {
-        "@remix-run/router": "1.20.0",
-        "react-router": "6.27.0"
+        "react-router": "7.0.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/react-scripts": {
@@ -15690,6 +15698,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -16748,6 +16761,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -10,7 +10,7 @@
     "react": "^18.3.1",
     "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0",
+    "react-router-dom": "^7.0.2",
     "reactstrap": "^9.2.3",
     "web-vitals": "^4.2.4"
   },

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -44,7 +44,7 @@
         <bootstrap.version>5.3.3</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v23.1.0</node.version>
+        <node.version>v23.3.0</node.version>
         <npm.version>10.9.0</npm.version>
 
         <!-- Plugin versions -->

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -34,9 +34,9 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->

--- a/microcoffeeoncloud-jwttest/pom.xml
+++ b/microcoffeeoncloud-jwttest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -34,11 +34,11 @@
         <!-- Library versions -->
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.16.1</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
+        <flapdoodle-embed-mongo.version>4.18.0</flapdoodle-embed-mongo.version>
+        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-location/src/test/java/study/microcoffee/location/api/LocationControllerTest.java
+++ b/microcoffeeoncloud-location/src/test/java/study/microcoffee/location/api/LocationControllerTest.java
@@ -10,10 +10,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import study.microcoffee.location.logging.HttpLoggingFilterTestConfig;
@@ -29,7 +29,7 @@ class LocationControllerTest {
 
     private static final String SERVICE_PATH = "/api/coffeeshop/nearest/{latitude}/{longitude}/{maxdistance}";
 
-    @MockBean
+    @MockitoBean
     private LocationRepository locationRepositoryMock;
 
     @Autowired

--- a/microcoffeeoncloud-location/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-location/src/test/resources/application-test.properties
@@ -18,4 +18,4 @@ spring.cloud.config.fail-fast=false
 eureka.client.enabled=false
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
-de.flapdoodle.mongodb.embedded.version=8.0.0-rc9
+de.flapdoodle.mongodb.embedded.version=8.0.3

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 
@@ -35,11 +35,12 @@
         <microcoffeeoncloud-certificates.version>1.0.0-SNAPSHOT</microcoffeeoncloud-certificates.version>
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
-        <flapdoodle-embed-mongo.version>4.16.1</flapdoodle-embed-mongo.version>
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <flapdoodle-embed-mongo.version>4.18.0</flapdoodle-embed-mongo.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
 
+        <mockwebserver.version>4.12.0</mockwebserver.version>
         <modelmapper.version>3.2.1</modelmapper.version>
-        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
@@ -245,6 +246,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microcoffeeoncloud-order/run-local.bat
+++ b/microcoffeeoncloud-order/run-local.bat
@@ -4,7 +4,7 @@ setlocal
 
 set ACTIVE_SPRING_PROFILES=devlocal
 set SPRING_CLOUD_CONFIG_URI=https://localhost:8454
-set ORDER_CLIENT_SECRET=KNBllvpC9waZ8UaUYxS9NmTHykXVyH8g
+set ORDER_CLIENT_SECRET=G6NB2uEqyE6dWqVqV7yI8HpA5LeBxFIi
 
 mvn spring-boot:run -Dspring-boot.run.profiles=%ACTIVE_SPRING_PROFILES%
 

--- a/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/common/http/HttpClientFactory.java
+++ b/microcoffeeoncloud-order/src/main/java/study/microcoffee/order/consumer/common/http/HttpClientFactory.java
@@ -7,10 +7,11 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -57,9 +58,7 @@ public class HttpClientFactory {
                 .setConnectionRequestTimeout(Timeout.ofSeconds(timeout)) //
                 .build()) //
             .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create() //
-                .setSSLSocketFactory(SSLConnectionSocketFactoryBuilder.create() //
-                    .setHostnameVerifier(hostnameVerifier) //
-                    .build()) //
+                .setTlsSocketStrategy(new DefaultClientTlsStrategy(SSLContexts.createSystemDefault(), hostnameVerifier)) //
                 .setDefaultSocketConfig(SocketConfig.custom() //
                     .setSoTimeout(Timeout.ofSeconds(timeout)) //
                     .build()) //

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/menu/MenuControllerTest.java
@@ -8,10 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import study.microcoffee.order.CharacterEncodingFilterTestConfig;
@@ -31,7 +31,7 @@ class MenuControllerTest {
 
     private static final String SERVICE_PATH = "/api/coffeeshop/menu";
 
-    @MockBean
+    @MockitoBean
     private MenuRepository menuRepositoryMock;
 
     @Autowired

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/api/order/OrderControllerTest.java
@@ -18,11 +18,11 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -52,10 +52,10 @@ class OrderControllerTest {
 
     private static final int COFFEE_SHOP_ID = 10;
 
-    @MockBean
+    @MockitoBean
     private OrderRepository orderRepositoryMock;
 
-    @MockBean()
+    @MockitoBean()
     @Qualifier(OrderController.CREDIT_RATING_CONSUMER)
     private CreditRatingConsumer creditRatingCustomerMock;
 

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/BasicCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/BasicCreditRatingConsumerTest.java
@@ -88,7 +88,7 @@ class BasicCreditRatingConsumerTest {
     }
 
     private String buildServiceUrl(String customerId) {
-        UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
+        UriComponents serviceUrl = UriComponentsBuilder.fromUriString(CREDITRATING_SERVICE_URL) //
             .path("/api/coffeeshop/creditrating") //
             .pathSegment(UriUtils.encodePathSegment(customerId, StandardCharsets.UTF_8.name())) //
             .build();

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/BasicRestClientCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/BasicRestClientCreditRatingConsumerTest.java
@@ -88,7 +88,7 @@ class BasicRestClientCreditRatingConsumerTest {
     }
 
     private String buildServiceUrl(String customerId) {
-        UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
+        UriComponents serviceUrl = UriComponentsBuilder.fromUriString(CREDITRATING_SERVICE_URL) //
             .path("/api/coffeeshop/creditrating") //
             .pathSegment(UriUtils.encode(customerId, StandardCharsets.UTF_8)) //
             .build();

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JCreditRatingConsumerTest.java
@@ -88,7 +88,7 @@ class Resilience4JCreditRatingConsumerTest {
     }
 
     private String buildServiceUrl(String customerId) {
-        UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
+        UriComponents serviceUrl = UriComponentsBuilder.fromUriString(CREDITRATING_SERVICE_URL) //
             .path("/api/coffeeshop/creditrating") //
             .pathSegment(UriUtils.encodePathSegment(customerId, StandardCharsets.UTF_8.name())) //
             .build();

--- a/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JRestClientCreditRatingConsumerTest.java
+++ b/microcoffeeoncloud-order/src/test/java/study/microcoffee/order/consumer/creditrating/Resilience4JRestClientCreditRatingConsumerTest.java
@@ -88,7 +88,7 @@ class Resilience4JRestClientCreditRatingConsumerTest {
     }
 
     private String buildServiceUrl(String customerId) {
-        UriComponents serviceUrl = UriComponentsBuilder.fromHttpUrl(CREDITRATING_SERVICE_URL) //
+        UriComponents serviceUrl = UriComponentsBuilder.fromUriString(CREDITRATING_SERVICE_URL) //
             .path("/api/coffeeshop/creditrating") //
             .pathSegment(UriUtils.encode(customerId, StandardCharsets.UTF_8)) //
             .build();

--- a/microcoffeeoncloud-order/src/test/resources/application-test.properties
+++ b/microcoffeeoncloud-order/src/test/resources/application-test.properties
@@ -40,4 +40,4 @@ spring.security.oauth2.client.registration.order-service.client-secret=123-abc-4
 spring.security.oauth2.client.registration.order-service.authorization-grant-type=client_credentials
 
 # Define the version of Embedded Mongo to download and use (check https://www.mongodb.com/try/download/community)
-de.flapdoodle.mongodb.embedded.version=8.0.0-rc9
+de.flapdoodle.mongodb.embedded.version=8.0.3


### PR DESCRIPTION
- Upgraded Spring Boot 3.3.4 -> 3.4.0.
  - Added com.squareup.okhttp3:mockserver dependency in pom, no longer managed by Spring Boot.
  - Fixed deprecated MockBean -> MockitoBean.
  - Fixed deprecated SSLConnectionSocketFactoryBuilder class in HttpClient 5 (HttpClientBuilder.setSSLSocketFactory -> setTlsSocketStrategy).
  - Fixed deprecated UriComponentsBuilder.fromHttpUrl -> fromUriString.
- Upgraded Spring Cloud 2023.0.3 -> 2024.0.0, Springdoc 2.6.0 -> 2.7.0 and other deps to latest versions.
- Updated frontend: react-router-dom 6.27.0 -> 7.0.2
- Frontend security fix: cross-spawn 7.0.3 -> 7.0.6
- Updated Node v23.1.0 -> v23.3.0
- Updated maven-surefire-plugin.version 3.5.1 -> 3.5.2