### PR TITLE
Springdoc 283 upgrade

### DIFF
--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.0.7
+FROM quay.io/keycloak/keycloak:26.0.8
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2024.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.3</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-database/pom.xml
+++ b/microcoffeeoncloud-database/pom.xml
@@ -17,7 +17,7 @@
         <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
 
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
-        <gmavenplus-plugin.version>4.0.1</gmavenplus-plugin.version>
+        <gmavenplus-plugin.version>4.1.1</gmavenplus-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2024.0.0</spring-cloud.version>
 
-        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.3</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.18.0</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.3</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -40,7 +40,7 @@
 
         <mockwebserver.version>4.12.0</mockwebserver.version>
         <modelmapper.version>3.2.2</modelmapper.version>
-        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.3</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>


### PR DESCRIPTION
- Upgraded SpringDoc 2.7.0 -> 2.8.3, keycloak 26.0.7 -> 26.0.8 and gmavenplus-plugin 4.0.1 -> 4.1.1.