### PR TITLE
Keycloak fix deprecated envvars

### DIFF
--- a/microcoffeeoncloud-authserver/docker-compose.yml
+++ b/microcoffeeoncloud-authserver/docker-compose.yml
@@ -6,8 +6,8 @@ services:
           - "8456:8456"
           - "8457:8457"
         environment:
-          - KEYCLOAK_ADMIN=admin
-          - KEYCLOAK_ADMIN_PASSWORD=admin
+          - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+          - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
         domainname: microcoffee.study
         entrypoint: ["/opt/keycloak/bin/kc.sh", "start-dev",
                      "--import-realm",

--- a/microcoffeeoncloud-authserver/k8s-service-aks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-aks.yml
@@ -45,9 +45,9 @@ spec:
         - containerPort: 8456
         - containerPort: 8457
         env:
-        - name: KEYCLOAK_ADMIN
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
           value: "admin"
-        - name: KEYCLOAK_ADMIN_PASSWORD
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: "admin"
 ---
 apiVersion: v1

--- a/microcoffeeoncloud-authserver/k8s-service-eks.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-eks.yml
@@ -45,9 +45,9 @@ spec:
         - containerPort: 8456
         - containerPort: 8457
         env:
-        - name: KEYCLOAK_ADMIN
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
           value: "admin"
-        - name: KEYCLOAK_ADMIN_PASSWORD
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: "admin"
 ---
 apiVersion: v1

--- a/microcoffeeoncloud-authserver/k8s-service-gke.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-gke.yml
@@ -45,9 +45,9 @@ spec:
         - containerPort: 8456
         - containerPort: 8457
         env:
-        - name: KEYCLOAK_ADMIN
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
           value: "admin"
-        - name: KEYCLOAK_ADMIN_PASSWORD
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: "admin"
 ---
 apiVersion: v1

--- a/microcoffeeoncloud-authserver/k8s-service-mkube.yml
+++ b/microcoffeeoncloud-authserver/k8s-service-mkube.yml
@@ -45,9 +45,9 @@ spec:
         - containerPort: 8456
         - containerPort: 8457
         env:
-        - name: KEYCLOAK_ADMIN
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
           value: "admin"
-        - name: KEYCLOAK_ADMIN_PASSWORD
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: "admin"
 ---
 apiVersion: v1

--- a/microcoffeeoncloud-authserver/run-local.bat
+++ b/microcoffeeoncloud-authserver/run-local.bat
@@ -2,10 +2,10 @@
 
 setlocal
 
-set KEYCLOAK_HOME=D:\bin\keycloak-25.0.4
+set KEYCLOAK_HOME=D:\bin\keycloak-26.2.0
 
-set KEYCLOAK_ADMIN=admin
-set KEYCLOAK_ADMIN_PASSWORD=admin
+set KC_BOOTSTRAP_ADMIN_USERNAME=admin
+set KC_BOOTSTRAP_ADMIN_PASSWORD=admin
 
 copy target\keystore\localhost.p12 %KEYCLOAK_HOME%\.
 


### PR DESCRIPTION
- Fixed deprecated Keycloak envvars: KEYCLOAK_ADMIN/KEYCLOAK_ADMIN_PASSWORD -> KC_BOOTSTRAP_ADMIN_USERNAME/KC_BOOTSTRAP_ADMIN_PASSWORD