### PR TITLE
Frontend backend updates

### DIFF
--- a/microcoffeeoncloud-authserver/Dockerfile
+++ b/microcoffeeoncloud-authserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.2.2
+FROM quay.io/keycloak/keycloak:26.2.4
 
 COPY --chown=keycloak src/main/keycloak/microcoffee-realm.json /opt/keycloak/data/import/
 COPY --chown=keycloak target/keystore/*.p12 /opt/microcoffee/keystore/

--- a/microcoffeeoncloud-creditrating/pom.xml
+++ b/microcoffeeoncloud-creditrating/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2024.0.1</spring-cloud.version>
 
-        <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.46.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "bootstrap": "^5.3.5",
+        "bootstrap": "^5.3.6",
         "react": "^18.3.1",
         "react-cookie": "^8.0.1",
         "react-dom": "^18.3.1",
@@ -5067,9 +5067,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
-      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
       "funding": [
         {
           "type": "github",

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^18.3.1",
         "react-cookie": "^8.0.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.5.3",
+        "react-router-dom": "^7.6.1",
         "reactstrap": "^9.2.3",
         "web-vitals": "^4.2.4"
       },
@@ -13686,14 +13686,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
-      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
+      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -13709,12 +13708,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.3.tgz",
-      "integrity": "sha512-cK0jSaTyW4jV9SRKAItMIQfWZ/D6WEZafgHuuCb9g+SjhLolY78qc+De4w/Cz9ybjvLzShAmaIMEXt8iF1Cm+A==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
+      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.5.3"
+        "react-router": "7.6.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16777,12 +16776,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/microcoffeeoncloud-gateway/app/package-lock.json
+++ b/microcoffeeoncloud-gateway/app/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.6.1",
         "reactstrap": "^9.2.3",
-        "web-vitals": "^4.2.4"
+        "web-vitals": "^5.0.1"
       },
       "devDependencies": {
         "react-scripts": "5.0.1"
@@ -17144,9 +17144,10 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.0.1.tgz",
+      "integrity": "sha512-BsULPWaCKAAtNntUz0aJq1cu1wyuWmDzf4N6vYNMbYA6zzQAf2pzCYbyClf+Ui2MI54bt225AwugXIfL1W+Syg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "bootstrap": "^5.3.5",
+    "bootstrap": "^5.3.6",
     "react": "^18.3.1",
     "react-cookie": "^8.0.1",
     "react-dom": "^18.3.1",

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -10,7 +10,7 @@
     "react": "^18.3.1",
     "react-cookie": "^8.0.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.5.3",
+    "react-router-dom": "^7.6.1",
     "reactstrap": "^9.2.3",
     "web-vitals": "^4.2.4"
   },

--- a/microcoffeeoncloud-gateway/app/package.json
+++ b/microcoffeeoncloud-gateway/app/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.6.1",
     "reactstrap": "^9.2.3",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^5.0.1"
   },
   "devDependencies": {
     "react-scripts": "5.0.1"

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -36,7 +36,7 @@
 
         <spring-cloud.version>2024.0.1</spring-cloud.version>
 
-        <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
 
         <!-- Angular -->
         <angularjs.version>1.8.2</angularjs.version> <!-- Keep 1.8.2 (1.8.3 jar is not found) -->

--- a/microcoffeeoncloud-gateway/pom.xml
+++ b/microcoffeeoncloud-gateway/pom.xml
@@ -44,8 +44,8 @@
         <bootstrap.version>5.3.5</bootstrap.version>
 
         <!-- React tool versions (see https://nodejs.org/en/download) -->
-        <node.version>v23.11.0</node.version>
-        <npm.version>10.9.2</npm.version>
+        <node.version>v24.1.0</node.version>
+        <npm.version>11.3.0</npm.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.46.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-location/pom.xml
+++ b/microcoffeeoncloud-location/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Remember to update the de.flapdoodle.mongodb.embedded.version property in application-test.properties -->
         <flapdoodle-embed-mongo.version>4.20.0</flapdoodle-embed-mongo.version>
-        <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.46.0</docker-maven-plugin.version>

--- a/microcoffeeoncloud-order/pom.xml
+++ b/microcoffeeoncloud-order/pom.xml
@@ -40,7 +40,7 @@
 
         <mockwebserver.version>4.12.0</mockwebserver.version>
         <modelmapper.version>3.2.3</modelmapper.version>
-        <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
 
         <!-- Plugin versions -->
         <docker-maven-plugin.version>0.46.0</docker-maven-plugin.version>


### PR DESCRIPTION
- Updated Springdoc 2.8.6 -> 2.8.8 and Keycloak 26.2.2 -> 26.2.4.
- Upgraded Node v23.11.0 -> v24.1.0 and npm 10.9.2 -> 11.3.0.
- Frontend update: bootstrap 5.3.5 -> 5.3.6
- Frontend update: react-router-dom 7.5.3 -> 7.6.1
- Frontend update: web-vitals 4.2.4 -> 5.0.1